### PR TITLE
feat: Add abilitity to search and filter by urgency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - main
   pull_request:
     branches: [ main ]
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,28 @@ kantui --attach
 
 **Note** - Your `~/.kantui` directory will automatically be mounted on initial run and any `KANTUI_` env variables will automatically be passed to the container.
 
+## Keybindings
+
+### Navigation
+- `j` or `↓` - Move cursor down
+- `k` or `↑` - Move cursor up
+- `h` or `←` - Move cursor left (switch to TODO column)
+- `l` or `→` - Move cursor right (switch to IN PROGRESS column)
+
+### Todo Management
+- `n` - Create a new todo
+- `e` - Edit the active todo
+- `x` - Delete the active todo
+- `ENTER` - Progress todo to next stage (TODO → IN PROGRESS → DONE)
+- `BACKSPACE` - Move todo back from IN PROGRESS to TODO
+- `[` - Move item up in the list
+- `]` - Move item down in the list
+
+### Search & Filter
+- `/` - Search todos by title or description
+- `f` - Filter todos by urgency level
+- `c` - Clear all active filters
+
+### Other
+- `q` - Quit the application
+

--- a/src/App.php
+++ b/src/App.php
@@ -645,7 +645,7 @@ class App
                 TodoUrgency::IMPORTANT->value => TodoUrgency::IMPORTANT->label(),
                 TodoUrgency::URGENT->value => TodoUrgency::URGENT->label(),
             ],
-            default: $currentFilter?->value ?? 'all'
+            default: $currentFilter->value ?? 'all'
         );
 
         if ($urgency === 'all') {

--- a/src/App.php
+++ b/src/App.php
@@ -7,6 +7,7 @@ use Kantui\Support\Context;
 use Kantui\Support\Cursor;
 use Kantui\Support\DataManager;
 use Kantui\Support\Enums\TodoType;
+use Kantui\Support\Enums\TodoUrgency;
 use PhpTui\Term\Actions;
 use PhpTui\Term\ClearType;
 use PhpTui\Term\Event\CharKeyEvent;
@@ -32,6 +33,8 @@ use Throwable;
 
 use function Amp\delay;
 use function Laravel\Prompts\clear;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
 
 class App
 {
@@ -380,17 +383,44 @@ class App
         }
 
         if ($event->char === '[' && ! is_null($this->activeType)) {
-            $this->manager->repositionActiveItem(-1);
-            $this->moveCursorUp();
+            // Prevent repositioning when filters are active
+            if (! $this->manager->getSearchFilter()->isActive()) {
+                $this->manager->repositionActiveItem(-1);
+                $this->moveCursorUp();
+            }
         }
 
         if ($event->char == ']' && ! is_null($this->activeType)) {
-            $this->manager->repositionActiveItem(1);
-            $this->moveCursorDown();
+            // Prevent repositioning when filters are active
+            if (! $this->manager->getSearchFilter()->isActive()) {
+                $this->manager->repositionActiveItem(1);
+                $this->moveCursorDown();
+            }
         }
 
         if ($event->char === 'x' && ! is_null($this->activeType)) {
             $this->handleDeleteTodo();
+        }
+
+        if ($event->char === '/') {
+            return function () {
+                $this->handleSearch();
+
+                return $this->restartApp($this->activeType, new Cursor(0, Cursor::INITIAL_PAGE));
+            };
+        }
+
+        if ($event->char === 'f') {
+            return function () {
+                $this->handleFilterByUrgency();
+
+                return $this->restartApp($this->activeType, new Cursor(0, Cursor::INITIAL_PAGE));
+            };
+        }
+
+        if ($event->char === 'c') {
+            $this->manager->getSearchFilter()->clear();
+            $this->resetCursor(TodoType::TODO, 0, Cursor::INITIAL_PAGE);
         }
 
         return false; // Continue event loop
@@ -584,6 +614,48 @@ class App
     }
 
     /**
+     * Handle search input from the user.
+     */
+    protected function handleSearch(): void
+    {
+        $currentQuery = $this->manager->getSearchFilter()->getSearchQuery();
+
+        $query = text(
+            label: 'Search todos (title/description):',
+            default: $currentQuery ?? '',
+            hint: 'Leave empty to clear search'
+        );
+
+        $this->manager->getSearchFilter()->setSearchQuery($query);
+    }
+
+    /**
+     * Handle urgency filter selection from the user.
+     */
+    protected function handleFilterByUrgency(): void
+    {
+        $currentFilter = $this->manager->getSearchFilter()->getUrgencyFilter();
+
+        $urgency = select(
+            label: 'Filter by urgency:',
+            options: [
+                'all' => 'All (Clear filter)',
+                TodoUrgency::LOW->value => TodoUrgency::LOW->label(),
+                TodoUrgency::NORMAL->value => TodoUrgency::NORMAL->label(),
+                TodoUrgency::IMPORTANT->value => TodoUrgency::IMPORTANT->label(),
+                TodoUrgency::URGENT->value => TodoUrgency::URGENT->label(),
+            ],
+            default: $currentFilter?->value ?? 'all'
+        );
+
+        if ($urgency === 'all') {
+            $this->manager->getSearchFilter()->setUrgencyFilter(null);
+        } else {
+            $this->manager->getSearchFilter()->setUrgencyFilter(TodoUrgency::from($urgency));
+        }
+    }
+
+    /**
      * Get style object to use on in the widget.
      */
     protected function getStyle(): Style
@@ -592,10 +664,35 @@ class App
     }
 
     /**
+     * Get the help text for the footer based on current state.
+     */
+    protected function getHelpText(): string
+    {
+        $searchFilter = $this->manager->getSearchFilter();
+
+        if ($searchFilter->isActive()) {
+            // When filtering, exclude item repositioning commands
+            return '  j (↓) | k (↑) | h (←) | l (→) | ENTER (progress) | BACKSPACE (move back) | n (new) | e (edit) | x (delete) | / (search) | f (filter) | c (clear filters) | q (quit)';
+        }
+
+        // Normal mode with all commands
+        return '  j (↓) | k (↑) | h (←) | l (→) | ENTER (progress) | BACKSPACE (move back) | [ (move item up) | ] (move item down) | n (new) | e (edit) | x (delete) | / (search) | f (filter) | c (clear filters) | q (quit)';
+    }
+
+    /**
      * Return the widget to be rendered.
      */
     protected function widget(): Widget
     {
+        $searchFilter = $this->manager->getSearchFilter();
+        $filterDescription = $searchFilter->getDescription();
+
+        $title = "Kantui: v$this->version | Context: {$this->context}";
+
+        if ($filterDescription !== '') {
+            $title .= " | FILTERED: $filterDescription";
+        }
+
         return GridWidget::default()
             ->direction(Direction::Vertical)
             ->constraints(Constraint::percentage(self::LAYOUT_MAIN_PERCENTAGE), Constraint::percentage(self::LAYOUT_FOOTER_PERCENTAGE))
@@ -603,9 +700,7 @@ class App
                 BlockWidget::default()
                     ->borders(Borders::ALL)
                     ->titles(
-                        Title::fromString(
-                            "Kantui: v$this->version | Context: {$this->context}"
-                        )
+                        Title::fromString($title)
                     )
                     ->style($this->getStyle())
                     ->widget(
@@ -629,9 +724,7 @@ class App
                             )
                     ),
                 ParagraphWidget::fromText(
-                    Text::fromString(
-                        '  j (↓) | k (↑) | h (←) | l (→) | ENTER (progress) | BACKSPACE (move back) | [ (move item up) | ] (move item down) | n (new) | e (edit) | x (delete) | q (quit)'
-                    )
+                    Text::fromString($this->getHelpText())
                 )->alignment(HorizontalAlignment::Right)->style($this->getStyle())
             );
     }

--- a/src/Support/DataManager.php
+++ b/src/Support/DataManager.php
@@ -76,6 +76,11 @@ class DataManager implements DataManagerInterface
     private bool $cacheNeedsRebuild = true;
 
     /**
+     * The search and filter state (static to persist across app restarts).
+     */
+    protected static ?SearchFilter $searchFilter = null;
+
+    /**
      * Create a new DataManager instance.
      *
      * @param  Context  $context  The application context
@@ -84,6 +89,11 @@ class DataManager implements DataManagerInterface
     {
         $this->todos = $this->loadTodos();
         $this->rebuildIndexCache();
+
+        // Initialize static search filter if not already set
+        if (static::$searchFilter === null) {
+            static::$searchFilter = new SearchFilter;
+        }
     }
 
     /**
@@ -318,6 +328,7 @@ class DataManager implements DataManagerInterface
      * Get todos by type and paginate them appropriately.
      *
      * Retrieves todos of a specific type and returns them as a paginated collection.
+     * Applies active search and filter criteria.
      *
      * @param  TodoType  $type  The type of todos to retrieve
      * @param  Cursor  $cursor  The cursor containing pagination information
@@ -327,7 +338,14 @@ class DataManager implements DataManagerInterface
     {
         $page = $cursor->page();
 
-        $todos = Collection::make($this->todos[$type->value])->paginate(static::PAGINATE_BY, $page);
+        $todos = $this->todos[$type->value];
+
+        // Apply search and filter
+        if (static::$searchFilter->isActive()) {
+            $todos = array_filter($todos, fn ($todo) => static::$searchFilter->matches($todo));
+        }
+
+        $todos = Collection::make($todos)->paginate(static::PAGINATE_BY, $page);
 
         return $todos;
     }
@@ -545,5 +563,15 @@ class DataManager implements DataManagerInterface
         }
 
         return $this->todoIndexCache[$type][$id] ?? false;
+    }
+
+    /**
+     * Get the search filter instance.
+     *
+     * @return SearchFilter The search filter instance
+     */
+    public function getSearchFilter(): SearchFilter
+    {
+        return static::$searchFilter;
     }
 }

--- a/src/Support/DataManager.php
+++ b/src/Support/DataManager.php
@@ -235,7 +235,7 @@ class DataManager implements DataManagerInterface
         if (! $activeTodo) {
             return;
         }
-        info('Edit the todo:');
+        info('Edit Todo:');
         $title = text('Title:', default: $activeTodo->title);
         $description = textarea('Description:', default: $activeTodo->description, required: true);
         $urgency = select(
@@ -264,7 +264,7 @@ class DataManager implements DataManagerInterface
      */
     public function createInteractively(): Todo
     {
-        info('Create a new todo:');
+        info('Create Todo:');
 
         $title = text('Title:');
 

--- a/src/Support/SearchFilter.php
+++ b/src/Support/SearchFilter.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Kantui\Support;
+
+use Kantui\Support\Enums\TodoUrgency;
+
+/**
+ * Manages search and filter state for the kanban board.
+ *
+ * The SearchFilter class handles search queries and urgency filters,
+ * providing methods to check if todos match the current criteria.
+ */
+class SearchFilter
+{
+    /**
+     * The current search query.
+     */
+    protected ?string $searchQuery = null;
+
+    /**
+     * The currently active urgency filter.
+     */
+    protected ?TodoUrgency $urgencyFilter = null;
+
+    /**
+     * Set the search query.
+     *
+     * @param  string|null  $query  The search query, or null to clear
+     */
+    public function setSearchQuery(?string $query): void
+    {
+        $this->searchQuery = $query ? trim($query) : null;
+    }
+
+    /**
+     * Get the current search query.
+     *
+     * @return string|null The current search query
+     */
+    public function getSearchQuery(): ?string
+    {
+        return $this->searchQuery;
+    }
+
+    /**
+     * Set the urgency filter.
+     *
+     * @param  TodoUrgency|null  $urgency  The urgency level to filter by, or null to clear
+     */
+    public function setUrgencyFilter(?TodoUrgency $urgency): void
+    {
+        $this->urgencyFilter = $urgency;
+    }
+
+    /**
+     * Get the current urgency filter.
+     *
+     * @return TodoUrgency|null The current urgency filter
+     */
+    public function getUrgencyFilter(): ?TodoUrgency
+    {
+        return $this->urgencyFilter;
+    }
+
+    /**
+     * Check if a todo matches the current search query.
+     *
+     * Searches in both title and description (case-insensitive).
+     *
+     * @param  Todo  $todo  The todo to check
+     * @return bool True if the todo matches the search query
+     */
+    public function matchesSearch(Todo $todo): bool
+    {
+        if ($this->searchQuery === null || $this->searchQuery === '') {
+            return true;
+        }
+
+        $query = strtolower($this->searchQuery);
+        $title = strtolower($todo->title);
+        $description = strtolower($todo->description);
+
+        return str_contains($title, $query) || str_contains($description, $query);
+    }
+
+    /**
+     * Check if a todo matches the current urgency filter.
+     *
+     * @param  Todo  $todo  The todo to check
+     * @return bool True if the todo matches the urgency filter
+     */
+    public function matchesUrgency(Todo $todo): bool
+    {
+        if ($this->urgencyFilter === null) {
+            return true;
+        }
+
+        return $todo->urgency === $this->urgencyFilter;
+    }
+
+    /**
+     * Check if a todo matches all active filters.
+     *
+     * @param  Todo  $todo  The todo to check
+     * @return bool True if the todo matches all active filters
+     */
+    public function matches(Todo $todo): bool
+    {
+        return $this->matchesSearch($todo) && $this->matchesUrgency($todo);
+    }
+
+    /**
+     * Check if any filters are active.
+     *
+     * @return bool True if there are active filters
+     */
+    public function isActive(): bool
+    {
+        return $this->searchQuery !== null || $this->urgencyFilter !== null;
+    }
+
+    /**
+     * Clear all filters and search query.
+     */
+    public function clear(): void
+    {
+        $this->searchQuery = null;
+        $this->urgencyFilter = null;
+    }
+
+    /**
+     * Get a human-readable description of active filters.
+     *
+     * @return string Description of active filters
+     */
+    public function getDescription(): string
+    {
+        $parts = [];
+
+        if ($this->searchQuery !== null) {
+            $parts[] = "Search: \"{$this->searchQuery}\"";
+        }
+
+        if ($this->urgencyFilter !== null) {
+            $parts[] = "Urgency: {$this->urgencyFilter->label()}";
+        }
+
+        return empty($parts) ? '' : implode(' | ', $parts);
+    }
+}

--- a/tests/Unit/SearchFilterTest.php
+++ b/tests/Unit/SearchFilterTest.php
@@ -1,0 +1,259 @@
+<?php
+
+use Kantui\Support\Context;
+use Kantui\Support\Enums\TodoType;
+use Kantui\Support\Enums\TodoUrgency;
+use Kantui\Support\SearchFilter;
+use Kantui\Support\Todo;
+
+beforeEach(function () {
+    $this->context = new Context('default');
+    $this->filter = new SearchFilter;
+});
+
+it('can set and get search query', function () {
+    $this->filter->setSearchQuery('test query');
+
+    expect($this->filter->getSearchQuery())->toBe('test query');
+});
+
+it('trims search query', function () {
+    $this->filter->setSearchQuery('  test query  ');
+
+    expect($this->filter->getSearchQuery())->toBe('test query');
+});
+
+it('can clear search query with null', function () {
+    $this->filter->setSearchQuery('test');
+    $this->filter->setSearchQuery(null);
+
+    expect($this->filter->getSearchQuery())->toBeNull();
+});
+
+it('can clear search query with empty string', function () {
+    $this->filter->setSearchQuery('test');
+    $this->filter->setSearchQuery('');
+
+    expect($this->filter->getSearchQuery())->toBeNull();
+});
+
+it('can set and get urgency filter', function () {
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->getUrgencyFilter())->toBe(TodoUrgency::URGENT);
+});
+
+it('can clear urgency filter', function () {
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+    $this->filter->setUrgencyFilter(null);
+
+    expect($this->filter->getUrgencyFilter())->toBeNull();
+});
+
+it('matches todo with search query in title', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug in authentication',
+        description: 'User login is broken',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setSearchQuery('authentication');
+
+    expect($this->filter->matchesSearch($todo))->toBeTrue();
+});
+
+it('matches todo with search query in description', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug',
+        description: 'User authentication is broken',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setSearchQuery('authentication');
+
+    expect($this->filter->matchesSearch($todo))->toBeTrue();
+});
+
+it('search is case insensitive', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix Bug',
+        description: 'Something',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setSearchQuery('bug');
+
+    expect($this->filter->matchesSearch($todo))->toBeTrue();
+});
+
+it('does not match todo without search query', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug',
+        description: 'User login is broken',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setSearchQuery('authentication');
+
+    expect($this->filter->matchesSearch($todo))->toBeFalse();
+});
+
+it('matches any todo when no search query is set', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug',
+        description: 'User login is broken',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    expect($this->filter->matchesSearch($todo))->toBeTrue();
+});
+
+it('matches todo with correct urgency', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug',
+        description: 'Something urgent',
+        urgency: TodoUrgency::URGENT,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->matchesUrgency($todo))->toBeTrue();
+});
+
+it('does not match todo with different urgency', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug',
+        description: 'Something urgent',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->matchesUrgency($todo))->toBeFalse();
+});
+
+it('matches any todo when no urgency filter is set', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix bug',
+        description: 'Something',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    expect($this->filter->matchesUrgency($todo))->toBeTrue();
+});
+
+it('matches todo with both search and urgency filters', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix authentication bug',
+        description: 'Something',
+        urgency: TodoUrgency::URGENT,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setSearchQuery('authentication');
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->matches($todo))->toBeTrue();
+});
+
+it('does not match todo when search matches but urgency does not', function () {
+    $todo = new Todo(
+        $this->context,
+        TodoType::TODO,
+        id: '123',
+        title: 'Fix authentication bug',
+        description: 'Something',
+        urgency: TodoUrgency::NORMAL,
+        created_at: '2024-01-01 00:00:00'
+    );
+
+    $this->filter->setSearchQuery('authentication');
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->matches($todo))->toBeFalse();
+});
+
+it('reports active when search query is set', function () {
+    $this->filter->setSearchQuery('test');
+
+    expect($this->filter->isActive())->toBeTrue();
+});
+
+it('reports active when urgency filter is set', function () {
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->isActive())->toBeTrue();
+});
+
+it('reports inactive when no filters are set', function () {
+    expect($this->filter->isActive())->toBeFalse();
+});
+
+it('can clear all filters', function () {
+    $this->filter->setSearchQuery('test');
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    $this->filter->clear();
+
+    expect($this->filter->getSearchQuery())->toBeNull();
+    expect($this->filter->getUrgencyFilter())->toBeNull();
+    expect($this->filter->isActive())->toBeFalse();
+});
+
+it('generates description for search filter', function () {
+    $this->filter->setSearchQuery('test query');
+
+    expect($this->filter->getDescription())->toBe('Search: "test query"');
+});
+
+it('generates description for urgency filter', function () {
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->getDescription())->toBe('Urgency: URGENT');
+});
+
+it('generates description for both filters', function () {
+    $this->filter->setSearchQuery('test');
+    $this->filter->setUrgencyFilter(TodoUrgency::URGENT);
+
+    expect($this->filter->getDescription())->toBe('Search: "test" | Urgency: URGENT');
+});
+
+it('generates empty description when no filters are set', function () {
+    expect($this->filter->getDescription())->toBe('');
+});


### PR DESCRIPTION
This pull request adds a comprehensive search and filter feature to the kanban board application, allowing users to search todos by title/description and filter by urgency. It introduces a new `SearchFilter` class to manage this state, updates the UI to reflect active filters, and ensures that todos are filtered and paginated correctly. The keybindings and help text are also updated for clarity, and thorough unit tests are included for the new functionality.

* Introduced the new `SearchFilter` class to manage search queries and urgency filters, with methods to match todos and provide filter status and descriptions.
* Integrated search and urgency filter handling into the main app: users can activate search (`/`), filter by urgency (`f`), and clear filters (`c`). The todo list is filtered accordingly, and item repositioning is disabled when filters are active. [[1]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR386-R425) [[2]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR616-R657)
* Updated keybindings documentation in `README.md` to include navigation, todo management, search/filter actions, and clarified their usage.
* Dynamically updated the kanban board title and help text to show active filters and context-sensitive command hints. [[1]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR666-R703) [[2]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL632-R727)
* Modified `DataManager` to persist search/filter state across app restarts and apply active filters when fetching todos. [[1]](diffhunk://#diff-e2286aa4da98ec12a8138a0dc8b3be471c227ff74216e5e99ddaa00e0b27665eR78-R82) [[2]](diffhunk://#diff-e2286aa4da98ec12a8138a0dc8b3be471c227ff74216e5e99ddaa00e0b27665eR92-R96) [[3]](diffhunk://#diff-e2286aa4da98ec12a8138a0dc8b3be471c227ff74216e5e99ddaa00e0b27665eR331) [[4]](diffhunk://#diff-e2286aa4da98ec12a8138a0dc8b3be471c227ff74216e5e99ddaa00e0b27665eL330-R348) [[5]](diffhunk://#diff-e2286aa4da98ec12a8138a0dc8b3be471c227ff74216e5e99ddaa00e0b27665eR567-R576)
* Added a thorough unit test suite for `SearchFilter`, covering all filter logic and description generation.
* Minor language changes to input labels when creating and editing todos. 