### PR TITLE
Extract core implementation to widget interface.

### DIFF
--- a/bin/kantui
+++ b/bin/kantui
@@ -25,6 +25,9 @@ try {
 
     exit($app->run());
 } catch (Throwable $e) {
+    // Ensure terminal is cleaned up before showing error
+    App::cleanupTerminal();
+
     if (filter_var(getenv('KANTUI_DEBUG'), FILTER_VALIDATE_BOOLEAN)) {
         throw $e;
     } else {

--- a/src/App.php
+++ b/src/App.php
@@ -2,30 +2,25 @@
 
 namespace Kantui;
 
-use Illuminate\Pagination\LengthAwarePaginator;
+use Kantui\Contracts\AppWidget;
 use Kantui\Support\Context;
 use Kantui\Support\Cursor;
 use Kantui\Support\DataManager;
 use Kantui\Support\Enums\TodoType;
-use Kantui\Support\Enums\TodoUrgency;
+use Kantui\Widgets\MainWidget;
 use PhpTui\Term\Actions;
 use PhpTui\Term\ClearType;
 use PhpTui\Term\Event\CharKeyEvent;
 use PhpTui\Term\Event\CodedKeyEvent;
-use PhpTui\Term\KeyCode;
-use PhpTui\Term\KeyModifiers;
+use PhpTui\Term\Event\MouseEvent;
 use PhpTui\Term\Terminal;
 use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend as PhpTuiPhpTermBackend;
 use PhpTui\Tui\Display\Display;
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Extension\Core\Widget\BlockWidget;
 use PhpTui\Tui\Extension\Core\Widget\GridWidget;
 use PhpTui\Tui\Extension\Core\Widget\ParagraphWidget;
 use PhpTui\Tui\Layout\Constraint;
-use PhpTui\Tui\Style\Style;
 use PhpTui\Tui\Text\Text;
-use PhpTui\Tui\Text\Title;
-use PhpTui\Tui\Widget\Borders;
 use PhpTui\Tui\Widget\Direction;
 use PhpTui\Tui\Widget\HorizontalAlignment;
 use PhpTui\Tui\Widget\Widget;
@@ -33,8 +28,6 @@ use Throwable;
 
 use function Amp\delay;
 use function Laravel\Prompts\clear;
-use function Laravel\Prompts\select;
-use function Laravel\Prompts\text;
 
 class App
 {
@@ -44,8 +37,6 @@ class App
     private const LAYOUT_MAIN_PERCENTAGE = 99;
 
     private const LAYOUT_FOOTER_PERCENTAGE = 1;
-
-    private const LAYOUT_HALF_PERCENTAGE = 50;
 
     /**
      * The app instance.
@@ -63,33 +54,32 @@ class App
     protected Display $display;
 
     /**
-     * The cursor instance.
-     */
-    protected Cursor $cursor;
-
-    /**
-     * The currently active todo type.
-     */
-    protected ?TodoType $activeType = null;
-
-    /**
      * The todo data manager.
      */
     protected DataManager $manager;
 
     /**
-     * The current page of todos.
+     * The currently active widget.
      */
-    protected LengthAwarePaginator $todos;
+    protected AppWidget $activeWidget;
 
     /**
-     * The current page of in progress todos.
+     * The main widget instance (saved for returning from help).
      */
-    protected LengthAwarePaginator $inProgress;
+    protected ?MainWidget $mainWidget = null;
+
+    /**
+     * Initial cursor and active type for app state.
+     */
+    protected Cursor $cursor;
+
+    protected TodoType $activeType;
 
     public function __construct(
         protected Context $context,
-        protected string $version
+        protected string $version,
+        ?Cursor $cursor = null,
+        ?TodoType $activeType = null
     ) {
         static::$terminal = isset(static::$terminal) ? static::$terminal : Terminal::new();
 
@@ -97,8 +87,8 @@ class App
             PhpTuiPhpTermBackend::new(static::$terminal)
         )->fullscreen()->build();
 
-        $this->cursor = new Cursor(0, Cursor::INITIAL_PAGE);
-        $this->activeType = TodoType::TODO;
+        $this->cursor = $cursor ?? new Cursor(0, Cursor::INITIAL_PAGE);
+        $this->activeType = $activeType ?? TodoType::TODO;
 
         static::$app = $this;
     }
@@ -132,26 +122,36 @@ class App
      */
     public static function cleanupTerminal(): void
     {
-        static::$terminal->disableRawMode();
-        static::$terminal->execute(Actions::cursorShow());
-        static::$terminal->execute(Actions::alternateScreenDisable());
-        static::$terminal->execute(Actions::disableMouseCapture());
+        if (! isset(static::$terminal)) {
+            return;
+        }
+
+        try {
+            static::$terminal->disableRawMode();
+            static::$terminal->execute(Actions::cursorShow());
+            static::$terminal->execute(Actions::alternateScreenDisable());
+            static::$terminal->execute(Actions::disableMouseCapture());
+        } catch (Throwable) {
+            // Ignore errors during cleanup
+        }
     }
 
     /**
-     * Set the active type.
+     * Set the active widget.
      */
-    public function setActiveType(TodoType $type): void
+    public function setActiveWidget(AppWidget $widget): void
     {
-        $this->activeType = $type;
+        $this->activeWidget = $widget;
     }
 
     /**
-     * Set the cursor position.
+     * Return to the main widget from another widget (e.g., help).
      */
-    public function setCursor(TodoType $type, Cursor $cursor): void
+    public function returnToMainWidget(): void
     {
-        $this->cursor->setIndex($cursor->index())->setPage($cursor->page());
+        if ($this->mainWidget !== null) {
+            $this->activeWidget = $this->mainWidget;
+        }
     }
 
     /**
@@ -160,6 +160,17 @@ class App
     public function run(): int
     {
         $this->manager = new DataManager($this->context);
+
+        // Initialize the main widget (this is the main todo/in progress home view)
+        $this->mainWidget = new MainWidget(
+            $this->manager,
+            $this->context,
+            $this->version,
+            $this->cursor,
+            $this->activeType
+        );
+
+        $this->setActiveWidget($this->mainWidget);
 
         try {
             static::$terminal->execute(Actions::cursorHide());
@@ -176,290 +187,7 @@ class App
     }
 
     /**
-     * Get the active items paginator based on the current active type.
-     */
-    protected function getActiveItems(): ?LengthAwarePaginator
-    {
-        return match ($this->activeType) {
-            TodoType::TODO => $this->todos,
-            TodoType::IN_PROGRESS => $this->inProgress,
-            default => null,
-        };
-    }
-
-    /**
-     * Move the cursor down.
-     */
-    protected function moveCursorDown(): void
-    {
-        if (is_null($this->activeType)) {
-            $this->activeType = TodoType::TODO;
-
-            if ($this->todos->count() === 0 && $this->inProgress->count() > 0) {
-                $this->activeType = TodoType::IN_PROGRESS;
-            }
-        }
-
-        $activeItems = $this->getActiveItems();
-
-        if ($activeItems === null || $activeItems->count() === 0) {
-            return;
-        }
-
-        $itemsOnPage = $activeItems->count();
-
-        // Prevent cursor from going out of bounds
-        if ($this->cursor->index() >= $itemsOnPage) {
-            return;
-        }
-
-        // If we can move down within the current page
-        if ($this->cursor->index() < $itemsOnPage - 1) {
-            $this->cursor->increment();
-
-            return;
-        }
-
-        // If we're at the end of the page and there are more pages
-        if ($this->cursor->index() == $itemsOnPage - 1 && $activeItems->hasMorePages()) {
-            $this->cursor->setIndex(0)->setPage($this->cursor->nextPage());
-        }
-    }
-
-    /**
-     * Move the cursor up.
-     */
-    protected function moveCursorUp(): void
-    {
-        $activeItems = $this->getActiveItems();
-
-        if ($activeItems === null || $activeItems->count() === 0) {
-            return;
-        }
-
-        $itemsOnPage = $activeItems->count();
-
-        // Clamp cursor to valid range if it's out of bounds
-        if ($this->cursor->index() >= $itemsOnPage) {
-            $this->cursor->setIndex($itemsOnPage - 1);
-
-            return;
-        }
-
-        // If we can move up within the current page
-        if ($this->cursor->index() > 0) {
-            $this->cursor->decrement();
-
-            return;
-        }
-
-        // If we're at the start of the page and not on the first page
-        if ($this->cursor->index() === 0 && $this->cursor->page() > Cursor::INITIAL_PAGE) {
-            $this->cursor->setIndex(DataManager::PAGINATE_BY - 1)->setPage($this->cursor->previousPage());
-        }
-    }
-
-    /**
-     * Move the cursor left.
-     */
-    protected function moveCursorLeft(): void
-    {
-        if ($this->todos->count() === 0) {
-            return;
-        }
-
-        // Cycle left: IN_PROGRESS -> TODO
-        if ($this->activeType === TodoType::IN_PROGRESS) {
-            $this->activeType = TodoType::TODO;
-            $this->cursor->setIndex(0)->setPage(Cursor::INITIAL_PAGE);
-        }
-    }
-
-    /**
-     * Swap the cursor between todo and in progress.
-     */
-    public function swapCursor(bool $focusLast = false): void
-    {
-        $swapTo = $this->activeType->opposite();
-        $this->activeType = $swapTo;
-
-        if ($focusLast) {
-            $paginator = $this->manager->getLastPageItems($swapTo);
-            $this->cursor->setIndex($paginator->count() - 1)->setPage($paginator->lastPage());
-        } else {
-            $this->cursor->setIndex(0)->setPage(Cursor::INITIAL_PAGE);
-        }
-
-        // if the new active type has no items, simply reset cursor and set active type to null
-        if ($this->manager->getByType($swapTo, $this->cursor)->total() === 0) {
-            $this->cursor->setIndex(0)->setPage(Cursor::INITIAL_PAGE);
-            $this->activeType = TodoType::TODO;
-        }
-    }
-
-    /**
-     * Move the cursor right.
-     */
-    protected function moveCursorRight(): void
-    {
-        if ($this->inProgress->count() === 0) {
-            return;
-        }
-
-        // Cycle right: TODO -> IN_PROGRESS
-        if ($this->activeType === TodoType::TODO) {
-            $this->activeType = TodoType::IN_PROGRESS;
-            $this->cursor->setIndex(0)->setPage(Cursor::INITIAL_PAGE);
-        }
-    }
-
-    /**
-     * Reset the cursor position.
-     */
-    protected function resetCursor(TodoType $type, int $index = Cursor::INACTIVE, int $page = Cursor::INITIAL_PAGE, bool $focusLast = false): void
-    {
-        if ($focusLast) {
-            $paginator = $this->manager->getLastPageItems($type);
-            $index = $paginator->count() - 1;
-            $page = $paginator->lastPage();
-        }
-        $this->cursor->setIndex($index)->setPage($page);
-    }
-
-    /**
-     * Get the cursor.
-     */
-    protected function getCursor(): Cursor
-    {
-        return $this->cursor;
-    }
-
-    /**
-     * Handle character key events.
-     */
-    protected function handleCharKeyEvent(CharKeyEvent $event): callable|false|null
-    {
-        if ($event->modifiers !== KeyModifiers::NONE) {
-            return null;
-        }
-
-        if ($event->char === 'q') {
-            return null; // Signal quit
-        }
-
-        if ($event->char == 'n') {
-            return function () {
-                $this->manager->createInteractively();
-                $paginator = $this->manager->getLastPageItems(TodoType::TODO);
-                $index = $paginator->count() - 1;
-                $page = $paginator->lastPage();
-
-                return $this->restartApp(TodoType::TODO, new Cursor($index, $page));
-            };
-        }
-
-        if ($event->char == 'e' && ! is_null($this->activeType)) {
-            return function () {
-                $this->manager->editInteractively();
-
-                return $this->restartApp($this->activeType, $this->cursor);
-            };
-        }
-
-        if ($event->char === 'j') {
-            $this->moveCursorDown();
-        }
-
-        if ($event->char === 'k') {
-            $this->moveCursorUp();
-        }
-
-        if ($event->char === 'h') {
-            $this->moveCursorLeft();
-        }
-
-        if ($event->char === 'l') {
-            $this->moveCursorRight();
-        }
-
-        if ($event->char === '[' && ! is_null($this->activeType)) {
-            // Prevent repositioning when filters are active
-            if (! $this->manager->getSearchFilter()->isActive()) {
-                $this->manager->repositionActiveItem(-1);
-                $this->moveCursorUp();
-            }
-        }
-
-        if ($event->char == ']' && ! is_null($this->activeType)) {
-            // Prevent repositioning when filters are active
-            if (! $this->manager->getSearchFilter()->isActive()) {
-                $this->manager->repositionActiveItem(1);
-                $this->moveCursorDown();
-            }
-        }
-
-        if ($event->char === 'x' && ! is_null($this->activeType)) {
-            $this->handleDeleteTodo();
-        }
-
-        if ($event->char === '/') {
-            return function () {
-                $this->handleSearch();
-
-                return $this->restartApp($this->activeType, new Cursor(0, Cursor::INITIAL_PAGE));
-            };
-        }
-
-        if ($event->char === 'f') {
-            return function () {
-                $this->handleFilterByUrgency();
-
-                return $this->restartApp($this->activeType, new Cursor(0, Cursor::INITIAL_PAGE));
-            };
-        }
-
-        if ($event->char === 'c') {
-            $this->manager->getSearchFilter()->clear();
-            $this->resetCursor(TodoType::TODO, 0, Cursor::INITIAL_PAGE);
-        }
-
-        return false; // Continue event loop
-    }
-
-    /**
-     * Handle coded key events.
-     */
-    protected function handleCodedKeyEvent(CodedKeyEvent $event): void
-    {
-        if ($event->code == KeyCode::Down) {
-            $this->moveCursorDown();
-        }
-
-        if ($event->code == KeyCode::Up) {
-            $this->moveCursorUp();
-        }
-
-        if ($event->code == KeyCode::Left) {
-            $this->moveCursorLeft();
-        }
-
-        if ($event->code == KeyCode::Right) {
-            $this->moveCursorRight();
-        }
-
-        if ($event->code == KeyCode::Enter) {
-            $this->handleEnterKey();
-        }
-
-        if ($event->code == KeyCode::Backspace && $this->activeType === TodoType::IN_PROGRESS) {
-            $this->manager->move($this->manager->getActiveTodo(), TodoType::TODO);
-            $this->activeType = TodoType::TODO;
-            $this->resetCursor(TodoType::TODO, focusLast: true);
-        }
-    }
-
-    /**
-     *  Start and render the TUI application and listen for events.
+     * Start and render the TUI application and listen for events.
      */
     protected function start(): int
     {
@@ -467,36 +195,33 @@ class App
 
         while (true) {
             while (null != ($event = static::$terminal->events()->next())) {
+                $result = null;
 
                 if ($event instanceof CharKeyEvent) {
-                    $result = $this->handleCharKeyEvent($event);
-
-                    if ($result === null) {
-                        break 2; // Quit
-                    }
-
-                    if (is_callable($result)) {
-                        $action = $result;
-                        break 2;
-                    }
+                    $result = $this->activeWidget->handleCharKey($event);
                 }
 
                 if ($event instanceof CodedKeyEvent) {
-                    $this->handleCodedKeyEvent($event);
+                    $result = $this->activeWidget->handleCodedKey($event);
+                }
+
+                if ($event instanceof MouseEvent) {
+                    // Ignore mouse events
+                    $result = false;
+                }
+
+                // Handle the result
+                if ($result === null) {
+                    break 2; // Quit
+                }
+
+                if (is_callable($result)) {
+                    $action = $result;
+                    break 2;
                 }
             }
 
-            $this->todos = $this->manager->getByType(
-                TodoType::TODO,
-                $this->activeType === TodoType::TODO ? $this->cursor : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE)
-            );
-
-            $this->inProgress = $this->manager->getByType(
-                TodoType::IN_PROGRESS,
-                $this->activeType === TodoType::IN_PROGRESS ? $this->cursor : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE)
-            );
-
-            $this->display->draw($this->widget());
+            $this->display->draw($this->buildLayout());
             delay(0.01);
         }
 
@@ -510,222 +235,35 @@ class App
         $action = null;
 
         return 0;
-
     }
 
     /**
-     * Adjust cursor position after deleting a todo.
+     * Build the main layout with widget and footer.
      */
-    protected function adjustCursorAfterDeletion(int $lastIndex, Cursor $cursor, LengthAwarePaginator $items): void
+    protected function buildLayout(): Widget
     {
-        // If the last index is 0 and we are on the first page and there are no more items, simply reset cursor.
-        if ($lastIndex === 0 && $cursor->page() === Cursor::INITIAL_PAGE && $items->count() === 0) {
-            $this->resetCursor($this->activeType);
-
-            return;
-        }
-
-        // If the last index is 0 and there are items on the current page, focus on the next item.
-        if ($lastIndex === 0 && $items->count() > 0) {
-            $this->resetCursor($this->activeType, index: 0, page: $cursor->page());
-
-            return;
-        }
-
-        // If there are no more items, reset the cursor.
-        if ($items->total() == 0) {
-            $this->resetCursor($this->activeType);
-
-            return;
-        }
-
-        // Choose last on previous page.
-        if ($items->count() === 0) {
-            $this->resetCursor($this->activeType, index: DataManager::PAGINATE_BY - 1, page: $cursor->page() - 1);
-
-            return;
-        }
-
-        // If there are still items on the current page, focus on the item before the item we just deleted.
-        if ($items->count() > 0) {
-            $newIndex = $lastIndex - 1;
-            $this->resetCursor($this->activeType, $newIndex, page: $cursor->page());
-        }
-    }
-
-    /**
-     * Handle deletion of active todo and adjust cursor position.
-     */
-    protected function handleDeleteTodo(): void
-    {
-        $activeTodo = $this->manager->getActiveTodo();
-        $lastIndex = $this->manager->getActiveIndex();
-
-        $this->manager->delete($activeTodo);
-
-        // Get the latest items for the active type after deletion.
-        $items = $this->manager->getByType($this->activeType, $this->cursor);
-
-        $this->adjustCursorAfterDeletion($lastIndex, $this->cursor, $items);
-    }
-
-    /**
-     * Handle the Enter key press to progress or complete todos.
-     */
-    protected function handleEnterKey(): void
-    {
-        $activeTodo = $this->manager->getActiveTodo();
-        $isBeingDone = $activeTodo->type == TodoType::IN_PROGRESS;
-
-        if ($this->context->config('delete_done', true) && $isBeingDone) {
-            $this->manager->delete($activeTodo);
-        } else {
-            $this->manager->move($activeTodo, $isBeingDone ? TodoType::DONE : TodoType::IN_PROGRESS);
-        }
-
-        if (! $isBeingDone) {
-            $this->swapCursor(focusLast: true);
-        } else {
-            $this->resetCursor(TodoType::IN_PROGRESS, index: 0, page: Cursor::INITIAL_PAGE);
-
-            if ($this->manager->getByType(TodoType::IN_PROGRESS, $this->cursor)->total() === 0) {
-                $this->swapCursor();
-            }
-        }
-    }
-
-    /**
-     * Restart the app with the given type and cursor.
-     */
-    protected function restartApp(?TodoType $type = null, ?Cursor $cursor = null): int
-    {
-        clear();
-        $app = new self($this->context, $this->version);
-
-        if ($type !== null) {
-            $app->setActiveType($type);
-        }
-
-        if ($cursor !== null && $type !== null) {
-            $app->setCursor($type, $cursor);
-        }
-
-        return $app->run();
-    }
-
-    /**
-     * Handle search input from the user.
-     */
-    protected function handleSearch(): void
-    {
-        $currentQuery = $this->manager->getSearchFilter()->getSearchQuery();
-
-        $query = text(
-            label: 'Search todos (title/description):',
-            default: $currentQuery ?? '',
-            hint: 'Leave empty to clear search'
-        );
-
-        $this->manager->getSearchFilter()->setSearchQuery($query);
-    }
-
-    /**
-     * Handle urgency filter selection from the user.
-     */
-    protected function handleFilterByUrgency(): void
-    {
-        $currentFilter = $this->manager->getSearchFilter()->getUrgencyFilter();
-
-        $urgency = select(
-            label: 'Filter by urgency:',
-            options: [
-                'all' => 'All (Clear filter)',
-                TodoUrgency::LOW->value => TodoUrgency::LOW->label(),
-                TodoUrgency::NORMAL->value => TodoUrgency::NORMAL->label(),
-                TodoUrgency::IMPORTANT->value => TodoUrgency::IMPORTANT->label(),
-                TodoUrgency::URGENT->value => TodoUrgency::URGENT->label(),
-            ],
-            default: $currentFilter->value ?? 'all'
-        );
-
-        if ($urgency === 'all') {
-            $this->manager->getSearchFilter()->setUrgencyFilter(null);
-        } else {
-            $this->manager->getSearchFilter()->setUrgencyFilter(TodoUrgency::from($urgency));
-        }
-    }
-
-    /**
-     * Get style object to use on in the widget.
-     */
-    protected function getStyle(): Style
-    {
-        return \Kantui\default_style();
-    }
-
-    /**
-     * Get the help text for the footer based on current state.
-     */
-    protected function getHelpText(): string
-    {
-        $searchFilter = $this->manager->getSearchFilter();
-
-        if ($searchFilter->isActive()) {
-            // When filtering, exclude item repositioning commands
-            return '  j (↓) | k (↑) | h (←) | l (→) | ENTER (progress) | BACKSPACE (move back) | n (new) | e (edit) | x (delete) | / (search) | f (filter) | c (clear filters) | q (quit)';
-        }
-
-        // Normal mode with all commands
-        return '  j (↓) | k (↑) | h (←) | l (→) | ENTER (progress) | BACKSPACE (move back) | [ (move item up) | ] (move item down) | n (new) | e (edit) | x (delete) | / (search) | f (filter) | c (clear filters) | q (quit)';
-    }
-
-    /**
-     * Return the widget to be rendered.
-     */
-    protected function widget(): Widget
-    {
-        $searchFilter = $this->manager->getSearchFilter();
-        $filterDescription = $searchFilter->getDescription();
-
-        $title = "Kantui: v$this->version | Context: {$this->context}";
-
-        if ($filterDescription !== '') {
-            $title .= " | Filtered: $filterDescription";
-        }
-
         return GridWidget::default()
             ->direction(Direction::Vertical)
-            ->constraints(Constraint::percentage(self::LAYOUT_MAIN_PERCENTAGE), Constraint::percentage(self::LAYOUT_FOOTER_PERCENTAGE))
+            ->constraints(
+                Constraint::percentage(self::LAYOUT_MAIN_PERCENTAGE),
+                Constraint::percentage(self::LAYOUT_FOOTER_PERCENTAGE)
+            )
             ->widgets(
-                BlockWidget::default()
-                    ->borders(Borders::ALL)
-                    ->titles(
-                        Title::fromString($title)
-                    )
-                    ->style($this->getStyle())
-                    ->widget(
-                        GridWidget::default()
-                            ->direction(Direction::Horizontal)
-                            ->constraints(
-                                Constraint::percentage(self::LAYOUT_HALF_PERCENTAGE),
-                                Constraint::percentage(self::LAYOUT_HALF_PERCENTAGE)
-                            )
-                            ->widgets(
-                                $this->manager->makeWidget(
-                                    TodoType::TODO,
-                                    $this->todos,
-                                    $this->activeType === TodoType::TODO ? $this->cursor : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE)
-                                ),
-                                $this->manager->makeWidget(
-                                    TodoType::IN_PROGRESS,
-                                    $this->inProgress,
-                                    $this->activeType === TodoType::IN_PROGRESS ? $this->cursor : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE)
-                                ),
-                            )
-                    ),
+                $this->activeWidget->render(),
                 ParagraphWidget::fromText(
-                    Text::fromString($this->getHelpText())
-                )->alignment(HorizontalAlignment::Right)->style($this->getStyle())
+                    Text::fromString($this->activeWidget->getFooterText())
+                )->alignment(HorizontalAlignment::Right)->style(\Kantui\default_style())
             );
+    }
+
+    /**
+     * Restart the app with new cursor position.
+     */
+    public function restartApp(?TodoType $type = null, ?Cursor $cursor = null): int
+    {
+        clear();
+        $app = new self($this->context, $this->version, $cursor, $type);
+
+        return $app->run();
     }
 }

--- a/src/Contracts/AppWidget.php
+++ b/src/Contracts/AppWidget.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kantui\Contracts;
+
+use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
+use PhpTui\Tui\Widget\Widget;
+
+/**
+ * Interface for application widgets that can be rendered and handle input events.
+ */
+interface AppWidget
+{
+    /**
+     * Render the widget.
+     *
+     * @return Widget The PhpTui widget to be rendered
+     */
+    public function render(): Widget;
+
+    /**
+     * Get the footer text to display at the bottom of the screen.
+     *
+     * @return string The footer help text
+     */
+    public function getFooterText(): string;
+
+    /**
+     * Handle character key events (a-z, 0-9, symbols, etc.).
+     *
+     * @param  CharKeyEvent  $event  The character key event
+     * @return callable|false|null
+     *                             - null: Signal to quit the application
+     *                             - callable: A function to execute (may restart the app)
+     *                             - false: Continue the event loop
+     */
+    public function handleCharKey(CharKeyEvent $event): callable|false|null;
+
+    /**
+     * Handle coded key events (arrows, enter, escape, etc.).
+     *
+     * @param  CodedKeyEvent  $event  The coded key event
+     * @return callable|false|null
+     *                             - null: Signal to quit the application
+     *                             - callable: A function to execute (may restart the app)
+     *                             - false: Continue the event loop
+     */
+    public function handleCodedKey(CodedKeyEvent $event): callable|false|null;
+}

--- a/src/Support/DataManager.php
+++ b/src/Support/DataManager.php
@@ -493,7 +493,7 @@ class DataManager implements DataManagerInterface
     {
         $title = Str::replace('_', ' ', $type->name);
 
-        if ($cursor->index() != Cursor::INACTIVE) {
+        if ($cursor->index() != Cursor::INACTIVE && $todos->total() > 0) {
             $current = ($cursor->index() + 1) + (($cursor->page() - 1) * static::PAGINATE_BY);
             $title = "$title - {$current}/{$todos->total()}";
         }

--- a/src/Widgets/HelpWidget.php
+++ b/src/Widgets/HelpWidget.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Kantui\Widgets;
+
+use Kantui\App;
+use Kantui\Contracts\AppWidget;
+use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
+use PhpTui\Term\KeyCode;
+use PhpTui\Term\KeyModifiers;
+use PhpTui\Tui\Extension\Core\Widget\BlockWidget;
+use PhpTui\Tui\Extension\Core\Widget\GridWidget;
+use PhpTui\Tui\Extension\Core\Widget\ParagraphWidget;
+use PhpTui\Tui\Layout\Constraint;
+use PhpTui\Tui\Style\Style;
+use PhpTui\Tui\Text\Text;
+use PhpTui\Tui\Text\Title;
+use PhpTui\Tui\Widget\Borders;
+use PhpTui\Tui\Widget\Direction;
+use PhpTui\Tui\Widget\HorizontalAlignment;
+use PhpTui\Tui\Widget\Widget;
+
+class HelpWidget implements AppWidget
+{
+    // Navigation bindings
+    public const MOVE_DOWN = 'j or ↓';
+
+    public const MOVE_UP = 'k or ↑';
+
+    public const MOVE_LEFT = 'h or ←';
+
+    public const MOVE_RIGHT = 'l or →';
+
+    // Item action bindings
+    public const PROGRESS_ITEM = 'ENTER';
+
+    public const REGRESS_ITEM = 'BACKSPACE';
+
+    public const NEW_ITEM = 'n';
+
+    public const EDIT_ITEM = 'e';
+
+    public const DELETE_ITEM = 'x';
+
+    // Reordering bindings
+    public const MOVE_ITEM_UP = '[';
+
+    public const MOVE_ITEM_DOWN = ']';
+
+    // Filter/Search bindings
+    public const SEARCH = '/';
+
+    public const FILTER_URGENCY = 'f';
+
+    public const CLEAR_FILTERS = 'c';
+
+    // Application bindings
+    public const TOGGLE_HELP = '?';
+
+    public const QUIT = 'q';
+
+    private bool $showReorderBindings;
+
+    private Style $style;
+
+    private ?App $app;
+
+    public function __construct(bool $showReorderBindings = true, ?Style $style = null, ?App $app = null)
+    {
+        $this->showReorderBindings = $showReorderBindings;
+        $this->style = $style ?? Style::default();
+        $this->app = $app;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(): Widget
+    {
+        $help = $this->buildHelpText();
+
+        $helpBlock = BlockWidget::default()
+            ->borders(Borders::ALL)
+            ->titles(Title::fromString('Available Keybindings Help - Press ? or ESC to close'))
+            ->style($this->style)
+            ->widget(
+                ParagraphWidget::fromText(
+                    Text::fromString($help)
+                )->alignment(HorizontalAlignment::Left)
+            );
+
+        // Center the help dialog with margins on both sides
+        return GridWidget::default()
+            ->direction(Direction::Horizontal)
+            ->constraints(
+                Constraint::percentage(10),  // Left margin
+                Constraint::percentage(80),  // Help content
+                Constraint::percentage(10)   // Right margin
+            )
+            ->widgets(
+                BlockWidget::default(),  // Empty left block
+                $helpBlock,
+                BlockWidget::default()   // Empty right block
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFooterText(): string
+    {
+        // No footer text for this widget, "q" is the only binding, we can put up by title.
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleCharKey(CharKeyEvent $event): callable|false|null
+    {
+        if ($event->modifiers !== KeyModifiers::NONE) {
+            return null;
+        }
+
+        // Close help on q or ?
+        if ($event->char === 'q' || $event->char === '?') {
+            if ($this->app !== null) {
+                $this->app->returnToMainWidget();
+            }
+        }
+
+        return false; // Continue event loop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleCodedKey(CodedKeyEvent $event): callable|false|null
+    {
+        // Close help on ESC
+        if ($event->code == KeyCode::Esc) {
+            if ($this->app !== null) {
+                $this->app->returnToMainWidget();
+            }
+        }
+
+        return false; // Continue event loop
+    }
+
+    /**
+     * Build the help text content.
+     */
+    private function buildHelpText(): string
+    {
+        $sections = [
+            'NAVIGATION' => [
+                self::MOVE_DOWN => 'Move cursor down',
+                self::MOVE_UP => 'Move cursor up',
+                self::MOVE_LEFT => 'Move to previous column/status',
+                self::MOVE_RIGHT => 'Move to next column/status',
+            ],
+            'ITEM ACTIONS' => [
+                self::PROGRESS_ITEM => 'Progress item to next status',
+                self::REGRESS_ITEM => 'Move item back to previous status',
+                self::NEW_ITEM => 'Create new todo item',
+                self::EDIT_ITEM => 'Edit selected item',
+                self::DELETE_ITEM => 'Delete selected item',
+            ],
+            'FILTERING & SEARCH' => [
+                self::SEARCH => 'Search/filter todos',
+                self::FILTER_URGENCY => 'Filter by urgency',
+                self::CLEAR_FILTERS => 'Clear all active filters',
+            ],
+            'APPLICATION' => [
+                self::TOGGLE_HELP => 'Toggle this help dialog',
+                self::QUIT => 'Quit application/Close help dialog',
+            ],
+        ];
+
+        // Add reordering section only if applicable
+        if ($this->showReorderBindings) {
+            $sections['ITEM REORDERING'] = [
+                self::MOVE_ITEM_UP => 'Move item up in list',
+                self::MOVE_ITEM_DOWN => 'Move item down in list',
+            ];
+        }
+
+        $lines = [];
+        $lines[] = '';  // Top padding
+
+        foreach ($sections as $sectionName => $bindings) {
+            $lines[] = "  $sectionName";
+            $lines[] = '  '.str_repeat('─', 50);
+
+            foreach ($bindings as $key => $description) {
+                $lines[] = sprintf('    %-15s  %s', $key, $description);
+            }
+
+            $lines[] = '';  // Section spacing
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Widgets/MainWidget.php
+++ b/src/Widgets/MainWidget.php
@@ -1,0 +1,568 @@
+<?php
+
+namespace Kantui\Widgets;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Kantui\App;
+use Kantui\Contracts\AppWidget;
+use Kantui\Support\Context;
+use Kantui\Support\Cursor;
+use Kantui\Support\DataManager;
+use Kantui\Support\Enums\TodoType;
+use Kantui\Support\Enums\TodoUrgency;
+use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
+use PhpTui\Term\KeyCode;
+use PhpTui\Term\KeyModifiers;
+use PhpTui\Tui\Extension\Core\Widget\BlockWidget;
+use PhpTui\Tui\Extension\Core\Widget\GridWidget;
+use PhpTui\Tui\Layout\Constraint;
+use PhpTui\Tui\Style\Style;
+use PhpTui\Tui\Text\Title;
+use PhpTui\Tui\Widget\Borders;
+use PhpTui\Tui\Widget\Direction;
+use PhpTui\Tui\Widget\Widget;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+class MainWidget implements AppWidget
+{
+    /**
+     * Layout percentage constants.
+     */
+    private const LAYOUT_HALF_PERCENTAGE = 50;
+
+    /**
+     * The cursor instance.
+     */
+    protected Cursor $cursor;
+
+    /**
+     * The currently active todo type.
+     */
+    protected ?TodoType $activeType = null;
+
+    /**
+     * The current page of todos.
+     */
+    protected LengthAwarePaginator $todos;
+
+    /**
+     * The current page of in progress todos.
+     */
+    protected LengthAwarePaginator $inProgress;
+
+    public function __construct(
+        protected DataManager $manager,
+        protected Context $context,
+        protected string $version,
+        Cursor $cursor,
+        TodoType $activeType
+    ) {
+        $this->cursor = $cursor;
+        $this->activeType = $activeType;
+        $this->refreshData();
+    }
+
+    /**
+     * Refresh the todo data from the manager.
+     */
+    protected function refreshData(): void
+    {
+        // Use appropriate cursor for each type
+        $todoCursor = $this->activeType === TodoType::TODO
+            ? $this->cursor
+            : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE);
+
+        $inProgressCursor = $this->activeType === TodoType::IN_PROGRESS
+            ? $this->cursor
+            : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE);
+
+        $this->todos = $this->manager->getByType(TodoType::TODO, $todoCursor);
+        $this->inProgress = $this->manager->getByType(TodoType::IN_PROGRESS, $inProgressCursor);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(): Widget
+    {
+        $searchFilter = $this->manager->getSearchFilter();
+        $filterDescription = $searchFilter->getDescription();
+
+        $title = "Kantui: v$this->version | Context: {$this->context}";
+
+        if ($filterDescription !== '') {
+            $title .= " | Filtered: $filterDescription";
+        }
+
+        return BlockWidget::default()
+            ->borders(Borders::ALL)
+            ->titles(
+                Title::fromString($title)
+            )
+            ->style($this->getStyle())
+            ->widget(
+                GridWidget::default()
+                    ->direction(Direction::Horizontal)
+                    ->constraints(
+                        Constraint::percentage(self::LAYOUT_HALF_PERCENTAGE),
+                        Constraint::percentage(self::LAYOUT_HALF_PERCENTAGE)
+                    )
+                    ->widgets(
+                        $this->manager->makeWidget(
+                            TodoType::TODO,
+                            $this->todos,
+                            $this->activeType === TodoType::TODO ? $this->cursor : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE)
+                        ),
+                        $this->manager->makeWidget(
+                            TodoType::IN_PROGRESS,
+                            $this->inProgress,
+                            $this->activeType === TodoType::IN_PROGRESS ? $this->cursor : new Cursor(Cursor::INACTIVE, Cursor::INITIAL_PAGE)
+                        ),
+                    )
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFooterText(): string
+    {
+        return '  ? (help) | q (quit)';
+    }
+
+    /**
+     * Get style object to use in the widget.
+     */
+    protected function getStyle(): Style
+    {
+        return \Kantui\default_style();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleCharKey(CharKeyEvent $event): callable|false|null
+    {
+        if ($event->modifiers !== KeyModifiers::NONE) {
+            return null;
+        }
+
+        if ($event->char === 'q') {
+            return null; // Signal quit
+        }
+
+        if ($event->char == 'n') {
+            return function () {
+                $this->manager->createInteractively();
+                $paginator = $this->manager->getLastPageItems(TodoType::TODO);
+                $index = $paginator->count() - 1;
+                $page = $paginator->lastPage();
+
+                return $this->restartApp(TodoType::TODO, new Cursor($index, $page));
+            };
+        }
+
+        if ($event->char == 'e' && ! is_null($this->activeType)) {
+            return function () {
+                $this->manager->editInteractively();
+
+                return $this->restartApp($this->activeType, $this->cursor);
+            };
+        }
+
+        if ($event->char === 'j') {
+            $this->moveCursorDown();
+        }
+
+        if ($event->char === 'k') {
+            $this->moveCursorUp();
+        }
+
+        if ($event->char === 'h') {
+            $this->moveCursorLeft();
+        }
+
+        if ($event->char === 'l') {
+            $this->moveCursorRight();
+        }
+
+        if ($event->char === '[' && ! is_null($this->activeType)) {
+            // Prevent repositioning when filters are active
+            if (! $this->manager->getSearchFilter()->isActive()) {
+                $this->manager->repositionActiveItem(-1);
+                $this->moveCursorUp();
+            }
+        }
+
+        if ($event->char == ']' && ! is_null($this->activeType)) {
+            // Prevent repositioning when filters are active
+            if (! $this->manager->getSearchFilter()->isActive()) {
+                $this->manager->repositionActiveItem(1);
+                $this->moveCursorDown();
+            }
+        }
+
+        if ($event->char === 'x' && ! is_null($this->activeType)) {
+            $this->handleDeleteTodo();
+        }
+
+        if ($event->char === '/') {
+            return function () {
+                $this->handleSearch();
+
+                return $this->restartApp($this->activeType, new Cursor(0, Cursor::INITIAL_PAGE));
+            };
+        }
+
+        if ($event->char === 'f') {
+            return function () {
+                $this->handleFilterByUrgency();
+
+                return $this->restartApp($this->activeType, new Cursor(0, Cursor::INITIAL_PAGE));
+            };
+        }
+
+        if ($event->char === 'c') {
+            return function () {
+                $this->manager->getSearchFilter()->clear();
+
+                return $this->restartApp($this->activeType ?? TodoType::TODO, new Cursor(0, Cursor::INITIAL_PAGE));
+            };
+        }
+
+        if ($event->char === '?') {
+            // Toggle  help widget
+            $app = App::getInstance();
+            $searchFilter = $this->manager->getSearchFilter();
+            $showReorderBindings = ! $searchFilter->isActive();
+
+            $app->setActiveWidget(new HelpWidget($showReorderBindings, $this->getStyle(), $app));
+        }
+
+        return false; // Continue event loop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleCodedKey(CodedKeyEvent $event): callable|false|null
+    {
+        if ($event->code == KeyCode::Down) {
+            $this->moveCursorDown();
+        }
+
+        if ($event->code == KeyCode::Up) {
+            $this->moveCursorUp();
+        }
+
+        if ($event->code == KeyCode::Left) {
+            $this->moveCursorLeft();
+        }
+
+        if ($event->code == KeyCode::Right) {
+            $this->moveCursorRight();
+        }
+
+        if ($event->code == KeyCode::Enter) {
+            $this->handleEnterKey();
+        }
+
+        if ($event->code == KeyCode::Backspace && $this->activeType === TodoType::IN_PROGRESS) {
+            $this->manager->move($this->manager->getActiveTodo(), TodoType::TODO);
+            $this->activeType = TodoType::TODO;
+            $this->resetCursor(TodoType::TODO, focusLast: true);
+
+            // Refresh both columns after move
+            $this->refreshData();
+        }
+
+        return false; // Continue event loop
+    }
+
+    /**
+     * Get the active items paginator based on the current active type.
+     */
+    protected function getActiveItems(): ?LengthAwarePaginator
+    {
+        return match ($this->activeType) {
+            TodoType::TODO => $this->todos,
+            TodoType::IN_PROGRESS => $this->inProgress,
+            default => null,
+        };
+    }
+
+    /**
+     * Move the cursor down.
+     */
+    protected function moveCursorDown(): void
+    {
+        if (is_null($this->activeType)) {
+            $this->activeType = TodoType::TODO;
+
+            if ($this->todos->count() === 0 && $this->inProgress->count() > 0) {
+                $this->activeType = TodoType::IN_PROGRESS;
+            }
+
+            $this->cursor->setIndex(0)->setPage(Cursor::INITIAL_PAGE);
+
+            return;
+        }
+
+        $items = $this->getActiveItems();
+
+        if ($items === null || $items->count() === 0) {
+            return;
+        }
+
+        if ($this->cursor->index() < $items->count() - 1) {
+            $this->cursor->increment();
+        } elseif ($items->hasMorePages()) {
+            $nextPage = $this->cursor->nextPage();
+            $this->cursor->setPage($nextPage)->setIndex(0);
+            $paginator = $this->manager->getByType($this->activeType, $this->cursor);
+            $this->todos = $this->activeType === TodoType::TODO ? $paginator : $this->todos;
+            $this->inProgress = $this->activeType === TodoType::IN_PROGRESS ? $paginator : $this->inProgress;
+        }
+    }
+
+    /**
+     * Move the cursor up.
+     */
+    protected function moveCursorUp(): void
+    {
+        if (is_null($this->activeType)) {
+            return;
+        }
+
+        $items = $this->getActiveItems();
+
+        if ($items === null || $items->count() === 0) {
+            return;
+        }
+
+        if ($this->cursor->index() > 0) {
+            $this->cursor->decrement();
+        } elseif ($this->cursor->page() > Cursor::INITIAL_PAGE) {
+            $prevPage = $this->cursor->previousPage();
+            $this->cursor->setPage($prevPage);
+            $paginator = $this->manager->getByType($this->activeType, $this->cursor);
+            $this->todos = $this->activeType === TodoType::TODO ? $paginator : $this->todos;
+            $this->inProgress = $this->activeType === TodoType::IN_PROGRESS ? $paginator : $this->inProgress;
+            $this->cursor->setIndex($paginator->count() - 1);
+        }
+    }
+
+    /**
+     * Move the cursor left.
+     */
+    protected function moveCursorLeft(): void
+    {
+        if ($this->activeType === TodoType::IN_PROGRESS) {
+            $this->swapCursor(TodoType::TODO);
+        } elseif ($this->activeType === TodoType::TODO) {
+            $this->swapCursor(TodoType::IN_PROGRESS);
+        }
+    }
+
+    /**
+     * Move the cursor right.
+     */
+    protected function moveCursorRight(): void
+    {
+        if ($this->activeType === TodoType::TODO) {
+            $this->swapCursor(TodoType::IN_PROGRESS);
+        } elseif ($this->activeType === TodoType::IN_PROGRESS) {
+            $this->swapCursor(TodoType::TODO);
+        }
+    }
+
+    /**
+     * Swap the cursor to a different todo type.
+     */
+    protected function swapCursor(TodoType $newType): void
+    {
+        $this->activeType = $newType;
+        $this->cursor->setIndex(0)->setPage(Cursor::INITIAL_PAGE);
+
+        $newPaginator = $this->manager->getByType($newType, $this->cursor);
+
+        if ($newPaginator->count() === 0) {
+            return;
+        }
+
+        if ($newType === TodoType::TODO) {
+            $this->todos = $newPaginator;
+        } else {
+            $this->inProgress = $newPaginator;
+        }
+    }
+
+    /**
+     * Reset the cursor position.
+     */
+    protected function resetCursor(TodoType $type, int $index = 0, int $page = Cursor::INITIAL_PAGE, bool $focusLast = false): void
+    {
+        $this->activeType = $type;
+        $this->cursor->setIndex($index)->setPage($page);
+
+        if ($focusLast) {
+            $lastPageItems = $this->manager->getLastPageItems($type);
+            $this->cursor->setIndex($lastPageItems->count() - 1)->setPage($lastPageItems->lastPage());
+        }
+    }
+
+    /**
+     * Get the cursor instance.
+     */
+    public function getCursor(): Cursor
+    {
+        return $this->cursor;
+    }
+
+    /**
+     * Get the active type.
+     */
+    public function getActiveType(): ?TodoType
+    {
+        return $this->activeType;
+    }
+
+    /**
+     * Handle the delete todo action.
+     */
+    protected function handleDeleteTodo(): void
+    {
+        $items = $this->getActiveItems();
+
+        if ($items === null || $items->count() === 0) {
+            return;
+        }
+
+        $todo = $this->manager->getActiveTodo();
+        $this->manager->delete($todo);
+
+        $this->adjustCursorAfterDeletion();
+    }
+
+    /**
+     * Handle the enter key to progress todos.
+     */
+    protected function handleEnterKey(): void
+    {
+        if (is_null($this->activeType)) {
+            return;
+        }
+
+        $items = $this->getActiveItems();
+
+        if ($items === null || $items->count() === 0) {
+            return;
+        }
+
+        $todo = $this->manager->getActiveTodo();
+        $targetType = $this->activeType->opposite();
+
+        $this->manager->move($todo, $targetType);
+
+        // Switch to the target type and focus the last item (newly moved item)
+        $this->activeType = $targetType;
+        $this->resetCursor($targetType, focusLast: true);
+
+        // Refresh both columns after move
+        $this->refreshData();
+    }
+
+    /**
+     * Adjust cursor position after a todo is deleted or moved.
+     */
+    protected function adjustCursorAfterDeletion(): void
+    {
+        $paginator = $this->manager->getByType($this->activeType, $this->cursor);
+        $itemCount = $paginator->count();
+
+        if ($this->activeType === TodoType::TODO) {
+            $this->todos = $paginator;
+        } else {
+            $this->inProgress = $paginator;
+        }
+
+        // If current page is now empty
+        if ($itemCount === 0) {
+            // If we're not on the first page, go back a page
+            if ($this->cursor->page() > Cursor::INITIAL_PAGE) {
+                $previousPage = $this->cursor->previousPage();
+                $this->cursor->setPage($previousPage);
+                $paginator = $this->manager->getByType($this->activeType, $this->cursor);
+
+                if ($this->activeType === TodoType::TODO) {
+                    $this->todos = $paginator;
+                } else {
+                    $this->inProgress = $paginator;
+                }
+
+                $this->cursor->setIndex($paginator->count() - 1);
+            } else {
+                // We're on page 1 and it's empty - set cursor to inactive
+                $this->cursor->setIndex(Cursor::INACTIVE);
+            }
+
+            return;
+        }
+
+        // If cursor index is beyond the new item count, adjust it
+        if ($this->cursor->index() >= $itemCount) {
+            $this->cursor->setIndex($itemCount - 1);
+        }
+    }
+
+    /**
+     * Handle search input.
+     */
+    protected function handleSearch(): void
+    {
+        $query = text(
+            label: 'Search Query',
+            placeholder: 'Enter search query...',
+            default: $this->manager->getSearchFilter()->getSearchQuery() ?? ''
+        );
+
+        $this->manager->getSearchFilter()->setSearchQuery($query);
+    }
+
+    /**
+     * Handle filter by urgency.
+     */
+    protected function handleFilterByUrgency(): void
+    {
+        $options = [
+            'all' => 'All Urgencies',
+            ...array_combine(
+                array_map(fn ($case) => $case->value, TodoUrgency::cases()),
+                array_map(fn ($case) => $case->label(), TodoUrgency::cases())
+            ),
+        ];
+
+        $selected = select(
+            label: 'Filter by Urgency',
+            options: $options,
+            default: $this->manager->getSearchFilter()->getUrgencyFilter()->value ?? 'all'
+        );
+
+        if ($selected === 'all') {
+            $this->manager->getSearchFilter()->setUrgencyFilter(null);
+        } else {
+            $this->manager->getSearchFilter()->setUrgencyFilter(TodoUrgency::from($selected));
+        }
+    }
+
+    /**
+     * Restart the app with new cursor position.
+     */
+    protected function restartApp(TodoType $activeType, Cursor $cursor): int
+    {
+        return App::getInstance()->restartApp($activeType, $cursor);
+    }
+}

--- a/tests/Unit/AppWidgetContractTest.php
+++ b/tests/Unit/AppWidgetContractTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Kantui\Contracts\AppWidget;
+use Kantui\Widgets\HelpWidget;
+use PhpTui\Tui\Widget\Widget;
+
+test('AppWidget interface defines required methods', function () {
+    $reflection = new ReflectionClass(AppWidget::class);
+
+    expect($reflection->hasMethod('render'))->toBeTrue()
+        ->and($reflection->hasMethod('getFooterText'))->toBeTrue()
+        ->and($reflection->hasMethod('handleCharKey'))->toBeTrue()
+        ->and($reflection->hasMethod('handleCodedKey'))->toBeTrue();
+});
+
+test('HelpWidget implements AppWidget interface', function () {
+    $widget = new HelpWidget;
+
+    expect($widget)->toBeInstanceOf(AppWidget::class);
+});
+
+test('HelpWidget render returns Widget', function () {
+    $widget = new HelpWidget;
+    $rendered = $widget->render();
+
+    expect($rendered)->toBeInstanceOf(Widget::class);
+});
+
+test('HelpWidget getFooterText returns string', function () {
+    $widget = new HelpWidget;
+    $footer = $widget->getFooterText();
+
+    expect($footer)->toBeString()
+        ->and(strlen($footer))->toBeGreaterThan(0);
+});
+
+test('AppWidget contract enforces return type for render', function () {
+    $reflection = new ReflectionClass(AppWidget::class);
+    $method = $reflection->getMethod('render');
+    $returnType = $method->getReturnType();
+
+    expect($returnType->getName())->toBe(Widget::class);
+});
+
+test('AppWidget contract enforces return type for getFooterText', function () {
+    $reflection = new ReflectionClass(AppWidget::class);
+    $method = $reflection->getMethod('getFooterText');
+    $returnType = $method->getReturnType();
+
+    expect($returnType->getName())->toBe('string');
+});
+
+test('AppWidget contract enforces parameter types for handleCharKey', function () {
+    $reflection = new ReflectionClass(AppWidget::class);
+    $method = $reflection->getMethod('handleCharKey');
+    $parameters = $method->getParameters();
+
+    expect($parameters)->toHaveCount(1)
+        ->and($parameters[0]->getType()->getName())->toBe('PhpTui\Term\Event\CharKeyEvent');
+});
+
+test('AppWidget contract enforces parameter types for handleCodedKey', function () {
+    $reflection = new ReflectionClass(AppWidget::class);
+    $method = $reflection->getMethod('handleCodedKey');
+    $parameters = $method->getParameters();
+
+    expect($parameters)->toHaveCount(1)
+        ->and($parameters[0]->getType()->getName())->toBe('PhpTui\Term\Event\CodedKeyEvent');
+});
+
+test('HelpWidget has all required keybinding constants', function () {
+    expect(defined('Kantui\Widgets\HelpWidget::MOVE_DOWN'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::MOVE_UP'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::MOVE_LEFT'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::MOVE_RIGHT'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::PROGRESS_ITEM'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::REGRESS_ITEM'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::NEW_ITEM'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::EDIT_ITEM'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::DELETE_ITEM'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::MOVE_ITEM_UP'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::MOVE_ITEM_DOWN'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::SEARCH'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::FILTER_URGENCY'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::CLEAR_FILTERS'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::TOGGLE_HELP'))->toBeTrue()
+        ->and(defined('Kantui\Widgets\HelpWidget::QUIT'))->toBeTrue();
+});
+
+test('HelpWidget footer text mentions help close keys', function () {
+    $widget = new HelpWidget;
+    $footer = $widget->getFooterText();
+
+    expect($footer)->toContain('?')
+        ->and($footer)->toContain('q')
+        ->and($footer)->toContain('ESC');
+});

--- a/tests/Unit/AppWidgetContractTest.php
+++ b/tests/Unit/AppWidgetContractTest.php
@@ -26,14 +26,6 @@ test('HelpWidget render returns Widget', function () {
     expect($rendered)->toBeInstanceOf(Widget::class);
 });
 
-test('HelpWidget getFooterText returns string', function () {
-    $widget = new HelpWidget;
-    $footer = $widget->getFooterText();
-
-    expect($footer)->toBeString()
-        ->and(strlen($footer))->toBeGreaterThan(0);
-});
-
 test('AppWidget contract enforces return type for render', function () {
     $reflection = new ReflectionClass(AppWidget::class);
     $method = $reflection->getMethod('render');
@@ -85,13 +77,4 @@ test('HelpWidget has all required keybinding constants', function () {
         ->and(defined('Kantui\Widgets\HelpWidget::CLEAR_FILTERS'))->toBeTrue()
         ->and(defined('Kantui\Widgets\HelpWidget::TOGGLE_HELP'))->toBeTrue()
         ->and(defined('Kantui\Widgets\HelpWidget::QUIT'))->toBeTrue();
-});
-
-test('HelpWidget footer text mentions help close keys', function () {
-    $widget = new HelpWidget;
-    $footer = $widget->getFooterText();
-
-    expect($footer)->toContain('?')
-        ->and($footer)->toContain('q')
-        ->and($footer)->toContain('ESC');
 });

--- a/tests/Unit/HelpWidgetTest.php
+++ b/tests/Unit/HelpWidgetTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use Kantui\Widgets\HelpWidget;
+use PhpTui\Tui\Extension\Core\Widget\GridWidget;
+use PhpTui\Tui\Style\Style;
+
+test('widget renders with default settings', function () {
+    $widget = new HelpWidget;
+    $rendered = $widget->render();
+
+    expect($rendered)->toBeInstanceOf(GridWidget::class);
+});
+
+test('widget renders with custom style', function () {
+    $style = Style::default();
+    $widget = new HelpWidget(true, $style);
+    $rendered = $widget->render();
+
+    expect($rendered)->toBeInstanceOf(GridWidget::class);
+});
+
+test('widget shows reorder bindings by default', function () {
+    $widget = new HelpWidget;
+
+    // Use reflection to access private buildHelpText method
+    $reflection = new ReflectionClass($widget);
+    $method = $reflection->getMethod('buildHelpText');
+    $method->setAccessible(true);
+    $helpText = $method->invoke($widget);
+
+    expect($helpText)->toContain('ITEM REORDERING')
+        ->and($helpText)->toContain('[')
+        ->and($helpText)->toContain(']');
+});
+
+test('widget hides reorder bindings when disabled', function () {
+    $widget = new HelpWidget(false);
+
+    // Use reflection to access private buildHelpText method
+    $reflection = new ReflectionClass($widget);
+    $method = $reflection->getMethod('buildHelpText');
+    $method->setAccessible(true);
+    $helpText = $method->invoke($widget);
+
+    expect($helpText)->not->toContain('ITEM REORDERING');
+});
+
+test('widget contains all navigation bindings', function () {
+    $widget = new HelpWidget;
+
+    $reflection = new ReflectionClass($widget);
+    $method = $reflection->getMethod('buildHelpText');
+    $method->setAccessible(true);
+    $helpText = $method->invoke($widget);
+
+    expect($helpText)->toContain('NAVIGATION')
+        ->and($helpText)->toContain('j or ↓')
+        ->and($helpText)->toContain('k or ↑')
+        ->and($helpText)->toContain('h or ←')
+        ->and($helpText)->toContain('l or →');
+});
+
+test('widget contains all item action bindings', function () {
+    $widget = new HelpWidget;
+
+    $reflection = new ReflectionClass($widget);
+    $method = $reflection->getMethod('buildHelpText');
+    $method->setAccessible(true);
+    $helpText = $method->invoke($widget);
+
+    expect($helpText)->toContain('ITEM ACTIONS')
+        ->and($helpText)->toContain('ENTER')
+        ->and($helpText)->toContain('BACKSPACE')
+        ->and($helpText)->toContain('n')
+        ->and($helpText)->toContain('e')
+        ->and($helpText)->toContain('x');
+});
+
+test('widget contains all filter and search bindings', function () {
+    $widget = new HelpWidget;
+
+    $reflection = new ReflectionClass($widget);
+    $method = $reflection->getMethod('buildHelpText');
+    $method->setAccessible(true);
+    $helpText = $method->invoke($widget);
+
+    expect($helpText)->toContain('FILTERING & SEARCH')
+        ->and($helpText)->toContain('/')
+        ->and($helpText)->toContain('f')
+        ->and($helpText)->toContain('c');
+});
+
+test('widget contains all application bindings', function () {
+    $widget = new HelpWidget;
+
+    $reflection = new ReflectionClass($widget);
+    $method = $reflection->getMethod('buildHelpText');
+    $method->setAccessible(true);
+    $helpText = $method->invoke($widget);
+
+    expect($helpText)->toContain('APPLICATION')
+        ->and($helpText)->toContain('?')
+        ->and($helpText)->toContain('q');
+});
+
+test('widget constants match expected values', function () {
+    expect(HelpWidget::MOVE_DOWN)->toBe('j or ↓')
+        ->and(HelpWidget::MOVE_UP)->toBe('k or ↑')
+        ->and(HelpWidget::MOVE_LEFT)->toBe('h or ←')
+        ->and(HelpWidget::MOVE_RIGHT)->toBe('l or →')
+        ->and(HelpWidget::PROGRESS_ITEM)->toBe('ENTER')
+        ->and(HelpWidget::REGRESS_ITEM)->toBe('BACKSPACE')
+        ->and(HelpWidget::NEW_ITEM)->toBe('n')
+        ->and(HelpWidget::EDIT_ITEM)->toBe('e')
+        ->and(HelpWidget::DELETE_ITEM)->toBe('x')
+        ->and(HelpWidget::MOVE_ITEM_UP)->toBe('[')
+        ->and(HelpWidget::MOVE_ITEM_DOWN)->toBe(']')
+        ->and(HelpWidget::SEARCH)->toBe('/')
+        ->and(HelpWidget::FILTER_URGENCY)->toBe('f')
+        ->and(HelpWidget::CLEAR_FILTERS)->toBe('c')
+        ->and(HelpWidget::TOGGLE_HELP)->toBe('?')
+        ->and(HelpWidget::QUIT)->toBe('q');
+});
+
+test('widget implements AppWidget interface', function () {
+    $widget = new HelpWidget;
+
+    expect($widget)->toBeInstanceOf(\Kantui\Contracts\AppWidget::class);
+});
+
+test('widget returns footer text', function () {
+    $widget = new HelpWidget;
+    $footerText = $widget->getFooterText();
+
+    expect($footerText)->toBeString()
+        ->and($footerText)->toContain('?')
+        ->and($footerText)->toContain('q');
+});

--- a/tests/Unit/HelpWidgetTest.php
+++ b/tests/Unit/HelpWidgetTest.php
@@ -127,12 +127,3 @@ test('widget implements AppWidget interface', function () {
 
     expect($widget)->toBeInstanceOf(\Kantui\Contracts\AppWidget::class);
 });
-
-test('widget returns footer text', function () {
-    $widget = new HelpWidget;
-    $footerText = $widget->getFooterText();
-
-    expect($footerText)->toBeString()
-        ->and($footerText)->toContain('?')
-        ->and($footerText)->toContain('q');
-});


### PR DESCRIPTION
This pull request introduces a new contract for application widgets and implements a `HelpWidget` to display keybindings and handle help-related input. It also moves core todo view into a `MainWidget`. It also adds unit tests to ensure the contract and widget behavior.

**Widget Contract and Implementation:**

* Added a new `AppWidget` interface in `src/Contracts/AppWidget.php` that defines required methods for rendering, footer text, and handling character/coded key events for application widgets.
* Implemented the `HelpWidget` in `src/Widgets/HelpWidget.php`, which provides a styled help dialog listing all keybindings, supports toggling reorder bindings, and handles input to close the dialog.

**Testing and Validation:**

* Added unit tests for the `AppWidget` contract and `HelpWidget` in `tests/Unit/AppWidgetContractTest.php`, verifying interface compliance, method signatures, keybinding constants, and correct widget behavior.
* Added targeted tests for `HelpWidget` in `tests/Unit/HelpWidgetTest.php` to check rendering, style customization, conditional display of reorder bindings, and the presence/values of all keybinding constants.

**Minor Improvement:**

* Improved the title formatting logic in `formatTypeTitle` to only show the cursor position when there are todos present.

**Bug Fixes**

* This PR also fixes issues with mouse events causing app to crash. 