### PR TITLE
feat: add tags and view todo widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ kantui --attach
 - `]` - Move item down in the list
 
 ### Search & Filter
-- `/` - Search todos by title or description
+- `/` - Search todos by tags or description
 - `f` - Filter todos by urgency level
 - `c` - Clear all active filters
 

--- a/bin/kantui
+++ b/bin/kantui
@@ -19,7 +19,7 @@ const KANTUI_VERSION = '0.5.0';
 try {
     $context = new Context(getenv('KANTUI_CONTEXT') ?: 'default');
 
-    $context->ensureDefaults();
+    $context->ensureDefaultFiles();
 
     $app = new App($context, KANTUI_VERSION);
 

--- a/generate.php
+++ b/generate.php
@@ -28,6 +28,10 @@ require __DIR__.'/vendor/autoload.php';
  */
 function parseArguments(array $argv): array
 {
+    if (str_contains($argv[1] ?? '', '--')) {
+        echo "Error: Context argument is missing or invalid.\n";
+        showUsage();
+    }
     $args = [
         'context' => $argv[1] ?? null,
         'force' => in_array('--force', $argv),
@@ -60,7 +64,7 @@ function generateTodos(Faker\Generator $faker, string $type, int $count): array
         $todos[] = [
             'id' => $faker->uuid,
             'urgency' => $faker->randomElement(['low', 'normal', 'urgent']),
-            'title' => $faker->sentence,
+            'tags' => $faker->words(rand(1, 3)),
             'description' => $faker->paragraph,
             'type' => $type,
             'created_at' => $faker->dateTimeBetween('-1 year', 'now')->format('Y-m-d H:i:s'),
@@ -108,7 +112,7 @@ if (! $args['force'] && file_exists($path = $context->path('data.json'))) {
     exit(1);
 }
 
-$context->ensureDefaults();
+$context->ensureDefaultFiles();
 
 // Initialize Faker
 $faker = Faker\Factory::create();

--- a/src/App.php
+++ b/src/App.php
@@ -261,7 +261,6 @@ class App
      */
     public function restartApp(?TodoType $type = null, ?Cursor $cursor = null): int
     {
-        clear();
         $app = new self($this->context, $this->version, $cursor, $type);
 
         return $app->run();

--- a/src/App.php
+++ b/src/App.php
@@ -27,7 +27,6 @@ use PhpTui\Tui\Widget\Widget;
 use Throwable;
 
 use function Amp\delay;
-use function Laravel\Prompts\clear;
 
 class App
 {

--- a/src/Contracts/ContextInterface.php
+++ b/src/Contracts/ContextInterface.php
@@ -44,5 +44,5 @@ interface ContextInterface
     /**
      * Ensure the context has default files present for writing.
      */
-    public function ensureDefaults(): void;
+    public function ensureDefaultFiles(): void;
 }

--- a/src/Support/Context.php
+++ b/src/Support/Context.php
@@ -170,7 +170,7 @@ class Context implements ContextInterface
      *
      * @throws RuntimeException if directory or file creation fails
      */
-    public function ensureDefaults(): void
+    public function ensureDefaultFiles(): void
     {
         if (! is_dir($contextPath = $this->path())) {
             $old = umask(0);

--- a/src/Support/SearchFilter.php
+++ b/src/Support/SearchFilter.php
@@ -65,7 +65,7 @@ class SearchFilter
     /**
      * Check if a todo matches the current search query.
      *
-     * Searches in both title and description (case-insensitive).
+     * Searches in tags and description (case-insensitive).
      *
      * @param  Todo  $todo  The todo to check
      * @return bool True if the todo matches the search query
@@ -77,10 +77,17 @@ class SearchFilter
         }
 
         $query = strtolower($this->searchQuery);
-        $title = strtolower($todo->title);
         $description = strtolower($todo->description);
 
-        return str_contains($title, $query) || str_contains($description, $query);
+        // Check if query matches any tag
+        foreach ($todo->tags as $tag) {
+            if (str_contains(strtolower($tag), $query)) {
+                return true;
+            }
+        }
+
+        // Check description
+        return str_contains($description, $query);
     }
 
     /**

--- a/src/Support/Todo.php
+++ b/src/Support/Todo.php
@@ -176,7 +176,7 @@ class Todo implements Arrayable
 
         // Truncate description if it exceeds max length
         if (mb_strlen($cleanDescription) > self::MAX_DESCRIPTION_LENGTH) {
-            $cleanDescription = mb_substr($cleanDescription, 0, self::MAX_DESCRIPTION_LENGTH - 3) . '...';
+            $cleanDescription = mb_substr($cleanDescription, 0, self::MAX_DESCRIPTION_LENGTH - 3).'...';
         }
 
         $lines[] = Line::fromSpans(Span::styled($cleanDescription, $descriptionStyle));

--- a/src/Support/Todo.php
+++ b/src/Support/Todo.php
@@ -12,6 +12,8 @@ use PhpTui\Tui\Extension\Core\Widget\GridWidget;
 use PhpTui\Tui\Extension\Core\Widget\ParagraphWidget;
 use PhpTui\Tui\Layout\Constraint;
 use PhpTui\Tui\Style\Style;
+use PhpTui\Tui\Text\Line;
+use PhpTui\Tui\Text\Span;
 use PhpTui\Tui\Text\Text;
 use PhpTui\Tui\Widget\Borders;
 use PhpTui\Tui\Widget\Direction;
@@ -22,8 +24,8 @@ use PhpTui\Tui\Widget\Widget;
  * Represents a single todo item in the kanban board.
  *
  * This class encapsulates all data and presentation logic for a todo item,
- * including its title, description, urgency level, creation timestamp, and
- * the visual widget representation in the terminal UI.
+ * including its tags, description, urgency level, creation timestamp, and
+ * the visual widget representation in the terminal UI with color-coded tag badges.
  */
 class Todo implements Arrayable
 {
@@ -43,20 +45,39 @@ class Todo implements Arrayable
     private const COLOR_LOW = [164, 208, 216];
 
     /**
+     * Tag color palette (cycles through for multiple tags).
+     */
+    private const TAG_COLORS = [
+        [0, 150, 255],    // Blue
+        [46, 197, 70],    // Green
+        [255, 193, 7],    // Yellow
+        [220, 53, 69],    // Red
+        [138, 43, 226],   // Purple
+        [255, 127, 80],   // Coral
+        [32, 178, 170],   // Teal
+        [255, 105, 180],  // Pink
+    ];
+
+    /**
      * Layout percentage constants.
      */
-    private const LAYOUT_TITLE_PERCENTAGE = 30;
+    private const LAYOUT_HEADER_PERCENTAGE = 30;
 
     private const LAYOUT_CONTENT_PERCENTAGE = 70;
 
     private const LAYOUT_HALF_PERCENTAGE = 50;
 
     /**
+     * Maximum description length before truncation.
+     */
+    private const MAX_DESCRIPTION_LENGTH = 100;
+
+    /**
      * Create a new todo item instance.
      *
      * @param  Context  $context  The application context for configuration access
      * @param  TodoType  $type  The current state of the todo (TODO, IN_PROGRESS, DONE)
-     * @param  string  $title  The todo item title
+     * @param  array  $tags  Array of tag strings for categorizing the todo
      * @param  string  $id  Unique identifier (UUID) for the todo
      * @param  string  $description  Detailed description of the todo
      * @param  TodoUrgency  $urgency  The urgency level (defaults to NORMAL)
@@ -65,7 +86,7 @@ class Todo implements Arrayable
     public function __construct(
         protected Context $context,
         public TodoType $type,
-        public string $title,
+        public array $tags,
         public string $id,
         public string $description,
         public TodoUrgency $urgency = TodoUrgency::NORMAL,
@@ -76,7 +97,7 @@ class Todo implements Arrayable
      * Get the widget for the todo item.
      *
      * Creates a visual representation of the todo using PhpTui widgets.
-     * The widget displays the urgency label, creation date, title, and description.
+     * The widget displays the urgency label, creation date, tag badges, and description.
      * When active, the widget has a highlighted background.
      *
      * @param  bool  $active  Whether this todo is currently selected/active
@@ -94,13 +115,22 @@ class Todo implements Arrayable
 
         $createdAt = Carbon::parse($this->created_at)->setTimezone($this->context->getTimezone());
 
+        // Build text content with styled tag badges
+        $contentText = $this->buildContentText($active, $style);
+
+        // Create a background-only style for the content paragraph (no foreground to preserve span colors)
+        $contentBgStyle = Style::default();
+        if ($active) {
+            $contentBgStyle = $contentBgStyle->bg(RgbColor::fromRgb(...self::COLOR_DARK_BG));
+        }
+
         return BlockWidget::default()
             ->borders(Borders::ALL)
             ->widget(
                 GridWidget::default()
                     ->direction(Direction::Vertical)
                     ->constraints(
-                        Constraint::percentage(self::LAYOUT_TITLE_PERCENTAGE),
+                        Constraint::percentage(self::LAYOUT_HEADER_PERCENTAGE),
                         Constraint::percentage(self::LAYOUT_CONTENT_PERCENTAGE),
                     )->widgets(
                         GridWidget::default()
@@ -122,15 +152,68 @@ class Todo implements Arrayable
                                     )
                                 )->style($style)->alignment(HorizontalAlignment::Right)
                             ),
-                        ParagraphWidget::fromText(
-                            Text::fromString(
-                                $this->title.PHP_EOL.PHP_EOL.
-                                $this->description
-                            )
-                        )->style($style)
+                        ParagraphWidget::fromText($contentText)->style($contentBgStyle)
                     )
             );
 
+    }
+
+    /**
+     * Build content text with styled tag badges.
+     *
+     * @param  bool  $active  Whether this todo is currently active
+     * @param  Style  $style  The base style for the text
+     * @return Text The formatted content with styled tags
+     */
+    protected function buildContentText(bool $active, Style $style): Text
+    {
+        $lines = [];
+
+        // First line: description with white text (no background, applied at paragraph level)
+        // Replace newlines with spaces to keep description on a single line
+        $descriptionStyle = Style::default()->fg(RgbColor::fromRgb(...self::COLOR_WHITE));
+        $cleanDescription = trim(preg_replace('/\s+/', ' ', $this->description));
+
+        // Truncate description if it exceeds max length
+        if (mb_strlen($cleanDescription) > self::MAX_DESCRIPTION_LENGTH) {
+            $cleanDescription = mb_substr($cleanDescription, 0, self::MAX_DESCRIPTION_LENGTH - 3) . '...';
+        }
+
+        $lines[] = Line::fromSpans(Span::styled($cleanDescription, $descriptionStyle));
+
+        // Add empty line for spacing
+        $emptyStyle = Style::default();
+        $lines[] = Line::fromSpans(Span::styled('', $emptyStyle));
+
+        // Third line: styled tag badges with "Tags: " prefix
+        $tagSpans = [];
+
+        // Add "Tags: " prefix (no background, applied at paragraph level)
+        $prefixStyle = Style::default()->fg(RgbColor::fromRgb(...self::COLOR_WHITE));
+        $tagSpans[] = Span::styled('Tags: ', $prefixStyle);
+
+        if (empty($this->tags)) {
+            $noTagsStyle = Style::default()->fg(RgbColor::fromRgb(...self::COLOR_WHITE));
+            $tagSpans[] = Span::styled('[No Tags]', $noTagsStyle);
+        } else {
+            foreach ($this->tags as $index => $tag) {
+                // Add space between tags
+                if ($index > 0) {
+                    $spaceStyle = Style::default()->fg(RgbColor::fromRgb(...self::COLOR_WHITE));
+                    $tagSpans[] = Span::styled(' ', $spaceStyle);
+                }
+
+                // Tag with color (no background, applied at paragraph level)
+                $color = $this->getTagColorByName($tag);
+                $tagStyle = Style::default()->fg(RgbColor::fromRgb(...$color));
+
+                $tagSpans[] = Span::styled("[{$tag}]", $tagStyle);
+            }
+        }
+
+        $lines[] = Line::fromSpans(...$tagSpans);
+
+        return Text::fromLines(...$lines);
     }
 
     /**
@@ -168,10 +251,45 @@ class Todo implements Arrayable
     {
         return [
             'type' => $this->type,
-            'title' => $this->title,
+            'tags' => $this->tags,
             'description' => $this->description,
             'urgency' => $this->urgency->value,
             'created_at' => $this->created_at,
         ];
+    }
+
+    /**
+     * Get the context instance.
+     *
+     * @return Context The application context
+     */
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    /**
+     * Get color for a specific tag based on its index.
+     *
+     * @param  int  $index  The index of the tag
+     * @return array RGB color array
+     */
+    protected function getTagColor(int $index): array
+    {
+        return self::TAG_COLORS[$index % count(self::TAG_COLORS)];
+    }
+
+    /**
+     * Generate a color for a tag based on its name hash.
+     *
+     * @param  string  $tag  The tag name
+     * @return array RGB color array
+     */
+    protected function getTagColorByName(string $tag): array
+    {
+        $hash = crc32($tag);
+        $index = abs($hash) % count(self::TAG_COLORS);
+
+        return self::TAG_COLORS[$index];
     }
 }

--- a/src/Widgets/HelpWidget.php
+++ b/src/Widgets/HelpWidget.php
@@ -42,6 +42,8 @@ class HelpWidget implements AppWidget
 
     public const DELETE_ITEM = 'x';
 
+    public const VIEW_DETAILS = 'i';
+
     // Reordering bindings
     public const MOVE_ITEM_UP = '[';
 
@@ -165,6 +167,7 @@ class HelpWidget implements AppWidget
                 self::NEW_ITEM => 'Create new todo item',
                 self::EDIT_ITEM => 'Edit selected item',
                 self::DELETE_ITEM => 'Delete selected item',
+                self::VIEW_DETAILS => 'View full todo details',
             ],
             'FILTERING & SEARCH' => [
                 self::SEARCH => 'Search/filter todos',

--- a/src/Widgets/TodoDetailWidget.php
+++ b/src/Widgets/TodoDetailWidget.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Kantui\Widgets;
+
+use Carbon\Carbon;
+use Kantui\App;
+use Kantui\Contracts\AppWidget;
+use Kantui\Support\Todo;
+use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
+use PhpTui\Term\KeyCode;
+use PhpTui\Term\KeyModifiers;
+use PhpTui\Tui\Color\RgbColor;
+use PhpTui\Tui\Extension\Core\Widget\BlockWidget;
+use PhpTui\Tui\Extension\Core\Widget\GridWidget;
+use PhpTui\Tui\Extension\Core\Widget\ParagraphWidget;
+use PhpTui\Tui\Layout\Constraint;
+use PhpTui\Tui\Style\Style;
+use PhpTui\Tui\Text\Line;
+use PhpTui\Tui\Text\Span;
+use PhpTui\Tui\Text\Text;
+use PhpTui\Tui\Text\Title;
+use PhpTui\Tui\Widget\Borders;
+use PhpTui\Tui\Widget\Direction;
+use PhpTui\Tui\Widget\HorizontalAlignment;
+use PhpTui\Tui\Widget\Widget;
+
+class TodoDetailWidget implements AppWidget
+{
+    /**
+     * RGB color constants.
+     */
+    private const COLOR_WHITE = [255, 255, 255];
+
+    private const COLOR_LABEL = [100, 150, 200];
+
+    /**
+     * Tag color palette (same as Todo class).
+     */
+    private const TAG_COLORS = [
+        [0, 150, 255],    // Blue
+        [46, 197, 70],    // Green
+        [255, 193, 7],    // Yellow
+        [220, 53, 69],    // Red
+        [138, 43, 226],   // Purple
+        [255, 127, 80],   // Coral
+        [32, 178, 170],   // Teal
+        [255, 105, 180],  // Pink
+    ];
+
+    private Todo $todo;
+
+    private Style $style;
+
+    private ?App $app;
+
+    public function __construct(Todo $todo, ?Style $style = null, ?App $app = null)
+    {
+        $this->todo = $todo;
+        $this->style = $style ?? Style::default();
+        $this->app = $app;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(): Widget
+    {
+        $detailText = $this->buildDetailText();
+
+        $detailBlock = BlockWidget::default()
+            ->borders(Borders::ALL)
+            ->titles(Title::fromString('Todo Details - Press i or ESC to close'))
+            ->style($this->style)
+            ->widget(
+                ParagraphWidget::fromText($detailText)
+                    ->alignment(HorizontalAlignment::Left)
+            );
+
+        // Center the detail dialog with margins on both sides
+        return GridWidget::default()
+            ->direction(Direction::Horizontal)
+            ->constraints(
+                Constraint::percentage(10),  // Left margin
+                Constraint::percentage(80),  // Detail content
+                Constraint::percentage(10)   // Right margin
+            )
+            ->widgets(
+                BlockWidget::default(),  // Empty left block
+                $detailBlock,
+                BlockWidget::default()   // Empty right block
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFooterText(): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleCharKey(CharKeyEvent $event): callable|false|null
+    {
+        if ($event->modifiers !== KeyModifiers::NONE) {
+            return null;
+        }
+
+        // Close detail view on i
+        if ($event->char === 'i') {
+            if ($this->app !== null) {
+                $this->app->returnToMainWidget();
+            }
+        }
+
+        return false; // Continue event loop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleCodedKey(CodedKeyEvent $event): callable|false|null
+    {
+        // Close detail view on ESC
+        if ($event->code == KeyCode::Esc) {
+            if ($this->app !== null) {
+                $this->app->returnToMainWidget();
+            }
+        }
+
+        return false; // Continue event loop
+    }
+
+    /**
+     * Build the detail text content.
+     */
+    private function buildDetailText(): Text
+    {
+        $lines = [];
+        $labelStyle = Style::default()->fg(RgbColor::fromRgb(...self::COLOR_LABEL));
+        $valueStyle = Style::default()->fg(RgbColor::fromRgb(...self::COLOR_WHITE));
+
+        // Add top padding
+        $lines[] = Line::fromString('');
+
+        // Urgency
+        $lines[] = Line::fromSpans(
+            Span::styled('  Urgency:     ', $labelStyle),
+            Span::styled($this->todo->urgency->label(), $valueStyle)
+        );
+
+        // Created date
+        $createdAt = Carbon::parse($this->todo->created_at)->setTimezone($this->todo->getContext()->getTimezone());
+        $dateStr = $createdAt->format('Y-m-d H:i:s') . ' (' . $createdAt->diffForHumans() . ')';
+        $lines[] = Line::fromSpans(
+            Span::styled('  Created:     ', $labelStyle),
+            Span::styled($dateStr, $valueStyle)
+        );
+
+        // Type
+        $lines[] = Line::fromSpans(
+            Span::styled('  Type:        ', $labelStyle),
+            Span::styled($this->todo->type->value, $valueStyle)
+        );
+
+        // ID
+        $lines[] = Line::fromSpans(
+            Span::styled('  ID:          ', $labelStyle),
+            Span::styled($this->todo->id, $valueStyle)
+        );
+
+        // Empty line before tags
+        $lines[] = Line::fromString('');
+
+        // Tags
+        $tagSpans = [Span::styled('  Tags:        ', $labelStyle)];
+
+        if (empty($this->todo->tags)) {
+            $tagSpans[] = Span::styled('[No Tags]', $valueStyle);
+        } else {
+            foreach ($this->todo->tags as $index => $tag) {
+                if ($index > 0) {
+                    $tagSpans[] = Span::styled(' ', $valueStyle);
+                }
+
+                $color = $this->getTagColorByName($tag);
+                $tagStyle = Style::default()->fg(RgbColor::fromRgb(...$color));
+                $tagSpans[] = Span::styled("[{$tag}]", $tagStyle);
+            }
+        }
+
+        $lines[] = Line::fromSpans(...$tagSpans);
+
+        // Empty line before description
+        $lines[] = Line::fromString('');
+        $lines[] = Line::fromString('');
+
+        // Description label
+        $lines[] = Line::fromSpans(Span::styled('  Description:', $labelStyle));
+        $lines[] = Line::fromString('  ' . str_repeat('─', 70));
+
+        // Split description into lines, preserving original line breaks
+        $descriptionLines = explode("\n", $this->todo->description);
+        foreach ($descriptionLines as $line) {
+            // Wrap long lines at 70 characters
+            $wrapped = wordwrap($line, 70, "\n", false);
+            $wrappedLines = explode("\n", $wrapped);
+            foreach ($wrappedLines as $wrappedLine) {
+                $lines[] = Line::fromSpans(Span::styled('  ' . $wrappedLine, $valueStyle));
+            }
+        }
+
+        return Text::fromLines(...$lines);
+    }
+
+    /**
+     * Generate a color for a tag based on its name hash.
+     *
+     * @param  string  $tag  The tag name
+     * @return array RGB color array
+     */
+    protected function getTagColorByName(string $tag): array
+    {
+        $hash = crc32($tag);
+        $index = abs($hash) % count(self::TAG_COLORS);
+
+        return self::TAG_COLORS[$index];
+    }
+}

--- a/src/Widgets/TodoDetailWidget.php
+++ b/src/Widgets/TodoDetailWidget.php
@@ -154,7 +154,7 @@ class TodoDetailWidget implements AppWidget
 
         // Created date
         $createdAt = Carbon::parse($this->todo->created_at)->setTimezone($this->todo->getContext()->getTimezone());
-        $dateStr = $createdAt->format('Y-m-d H:i:s') . ' (' . $createdAt->diffForHumans() . ')';
+        $dateStr = $createdAt->format('Y-m-d H:i:s').' ('.$createdAt->diffForHumans().')';
         $lines[] = Line::fromSpans(
             Span::styled('  Created:     ', $labelStyle),
             Span::styled($dateStr, $valueStyle)
@@ -200,7 +200,7 @@ class TodoDetailWidget implements AppWidget
 
         // Description label
         $lines[] = Line::fromSpans(Span::styled('  Description:', $labelStyle));
-        $lines[] = Line::fromString('  ' . str_repeat('─', 70));
+        $lines[] = Line::fromString('  '.str_repeat('─', 70));
 
         // Split description into lines, preserving original line breaks
         $descriptionLines = explode("\n", $this->todo->description);
@@ -209,7 +209,7 @@ class TodoDetailWidget implements AppWidget
             $wrapped = wordwrap($line, 70, "\n", false);
             $wrappedLines = explode("\n", $wrapped);
             foreach ($wrappedLines as $wrappedLine) {
-                $lines[] = Line::fromSpans(Span::styled('  ' . $wrappedLine, $valueStyle));
+                $lines[] = Line::fromSpans(Span::styled('  '.$wrappedLine, $valueStyle));
             }
         }
 

--- a/tests/Integration/ContextTest.php
+++ b/tests/Integration/ContextTest.php
@@ -44,14 +44,14 @@ test('path with relative path', function () {
 
 test('ensure defaults creates directory', function () {
     $context = new Context('test');
-    $context->ensureDefaults();
+    $context->ensureDefaultFiles();
 
     expect($context->path())->toBeDirectory();
 });
 
 test('ensure defaults creates data file', function () {
     $context = new Context('test');
-    $context->ensureDefaults();
+    $context->ensureDefaultFiles();
 
     $dataFile = $context->path('data.json');
     expect($dataFile)->toBeFile();
@@ -72,7 +72,7 @@ test('config returns default when no config file', function () {
 
 test('config loads from file', function () {
     $context = new Context('test');
-    $context->ensureDefaults();
+    $context->ensureDefaultFiles();
 
     $configPath = $context->path('config.json');
     file_put_contents($configPath, json_encode(['timezone' => 'America/New_York']));
@@ -93,7 +93,7 @@ test('get timezone returns default', function () {
 
 test('directory permissions', function () {
     $context = new Context('test');
-    $context->ensureDefaults();
+    $context->ensureDefaultFiles();
 
     $perms = fileperms($context->path());
     // Check that group write is not set (should be 0755 or similar)

--- a/tests/Integration/DataManagerTest.php
+++ b/tests/Integration/DataManagerTest.php
@@ -9,7 +9,7 @@ use Kantui\Support\Todo;
 beforeEach(function () {
     $this->testDir = setupTestEnvironment();
     $this->context = new Context('test');
-    $this->context->ensureDefaults();
+    $this->context->ensureDefaultFiles();
 });
 
 afterEach(function () {
@@ -41,7 +41,7 @@ test('get by type returns paginated results', function () {
         'todo' => [
             [
                 'id' => '123',
-                'title' => 'Test Todo',
+                'tags' => ['test'],
                 'description' => 'Test Description',
                 'urgency' => 'normal',
                 'created_at' => '2025-01-01 00:00:00',
@@ -66,7 +66,7 @@ test('delete removes todo', function () {
         'todo' => [
             [
                 'id' => '123',
-                'title' => 'Test Todo',
+                'tags' => ['test'],
                 'description' => 'Test Description',
                 'urgency' => 'normal',
                 'created_at' => '2025-01-01 00:00:00',
@@ -96,7 +96,7 @@ test('move changes todo type', function () {
         'todo' => [
             [
                 'id' => '123',
-                'title' => 'Test Todo',
+                'tags' => ['test', 'todo'],
                 'description' => 'Test Description',
                 'urgency' => 'normal',
                 'created_at' => '2025-01-01 00:00:00',
@@ -120,7 +120,7 @@ test('move changes todo type', function () {
 
     expect($todoItems)->toHaveCount(0)
         ->and($inProgressItems)->toHaveCount(1)
-        ->and($inProgressItems->first()->title)->toBe('Test Todo');
+        ->and($inProgressItems->first()->tags)->toBe(['test', 'todo']);
 });
 
 test('get last page items', function () {
@@ -135,7 +135,7 @@ test('get last page items', function () {
     for ($i = 1; $i <= 13; $i++) {
         $testData['todo'][] = [
             'id' => "id-$i",
-            'title' => "Todo $i",
+            'tags' => ["todo-$i"],
             'description' => "Description $i",
             'urgency' => 'normal',
             'created_at' => '2025-01-01 00:00:00',

--- a/tests/Unit/SearchFilterTest.php
+++ b/tests/Unit/SearchFilterTest.php
@@ -50,12 +50,12 @@ it('can clear urgency filter', function () {
     expect($this->filter->getUrgencyFilter())->toBeNull();
 });
 
-it('matches todo with search query in title', function () {
+it('matches todo with search query in tags', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug', 'authentication'],
         id: '123',
-        title: 'Fix bug in authentication',
         description: 'User login is broken',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -70,8 +70,8 @@ it('matches todo with search query in description', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug'],
         id: '123',
-        title: 'Fix bug',
         description: 'User authentication is broken',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -86,8 +86,8 @@ it('search is case insensitive', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['Fix', 'Bug'],
         id: '123',
-        title: 'Fix Bug',
         description: 'Something',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -102,8 +102,8 @@ it('does not match todo without search query', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug'],
         id: '123',
-        title: 'Fix bug',
         description: 'User login is broken',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -118,8 +118,8 @@ it('matches any todo when no search query is set', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug'],
         id: '123',
-        title: 'Fix bug',
         description: 'User login is broken',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -132,8 +132,8 @@ it('matches todo with correct urgency', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug'],
         id: '123',
-        title: 'Fix bug',
         description: 'Something urgent',
         urgency: TodoUrgency::URGENT,
         created_at: '2024-01-01 00:00:00'
@@ -148,8 +148,8 @@ it('does not match todo with different urgency', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug'],
         id: '123',
-        title: 'Fix bug',
         description: 'Something urgent',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -164,8 +164,8 @@ it('matches any todo when no urgency filter is set', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['bug'],
         id: '123',
-        title: 'Fix bug',
         description: 'Something',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'
@@ -178,8 +178,8 @@ it('matches todo with both search and urgency filters', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['authentication', 'bug'],
         id: '123',
-        title: 'Fix authentication bug',
         description: 'Something',
         urgency: TodoUrgency::URGENT,
         created_at: '2024-01-01 00:00:00'
@@ -195,8 +195,8 @@ it('does not match todo when search matches but urgency does not', function () {
     $todo = new Todo(
         $this->context,
         TodoType::TODO,
+        tags: ['authentication', 'bug'],
         id: '123',
-        title: 'Fix authentication bug',
         description: 'Something',
         urgency: TodoUrgency::NORMAL,
         created_at: '2024-01-01 00:00:00'


### PR DESCRIPTION
This PR:

- Removes "title" from todos in favor of a new "tags" field.
- Shows tags below todo description.
- FIxes issue where long todo text cuts off and pushes anything below out of view by truncating text.
- Add a "i" keymap that opens new "TodoDetailWidget" to allow viewing full text now that full description is truncated.
- Updates search filtering to use tags instead of title. 
- Various other minor refactors and cleanup.