### PR TITLE
fix: items not deleted/marked as done in enter handler

### DIFF
--- a/bin/kantui
+++ b/bin/kantui
@@ -17,7 +17,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
     throw new RuntimeException($message . ' in ' . $file . ' at line: ' . $line);
 });
 
-const KANTUI_VERSION = '0.6.1';
+const KANTUI_VERSION = '0.6.2';
 
 try {
     $context = new Context(getenv('KANTUI_CONTEXT') ?: 'default');

--- a/src/Widgets/MainWidget.php
+++ b/src/Widgets/MainWidget.php
@@ -481,7 +481,22 @@ class MainWidget implements AppWidget
         }
 
         $todo = $this->manager->getActiveTodo();
-        $targetType = $this->activeType->opposite();
+
+        // When item is in progress, complete it (delete or move to done based on config)
+        if ($this->activeType === TodoType::IN_PROGRESS) {
+            if ($this->context->config('delete_done', false)) {
+                $this->manager->delete($todo);
+                $this->adjustCursorAfterDeletion();
+            } else {
+                $this->manager->move($todo, TodoType::DONE);
+                $this->adjustCursorAfterDeletion();
+            }
+
+            return;
+        }
+
+        // Move TODO items to IN_PROGRESS
+        $targetType = TodoType::IN_PROGRESS;
 
         $this->manager->move($todo, $targetType);
 


### PR DESCRIPTION
This pull request updates the behavior of the Enter key in the `MainWidget` to streamline how TODO items are marked as in progress or completed. Now, pressing Enter on an "in progress" item will either delete it or move it to "done" based on configuration, while pressing Enter on a regular TODO will move it to "in progress".

Behavior changes to Enter key handling:

* When pressing Enter on a TODO in the `IN_PROGRESS` state, the item will be either deleted or moved to `DONE` depending on the `delete_done` configuration, and the cursor will be adjusted accordingly.
* Pressing Enter on a regular TODO now always moves it to `IN_PROGRESS`, instead of toggling between types.